### PR TITLE
feat(cli) (ENG-9310): add two-phase deploy (build-only + register-only)

### DIFF
--- a/apps/supervisor/Containerfile
+++ b/apps/supervisor/Containerfile
@@ -25,7 +25,8 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm fetch -
 FROM deps-fetcher AS dev-deps
 ENV NODE_ENV development
 
-RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile --offline --ignore-scripts
+# TEMP --no-frozen-lockfile and remove --offline for overrides for CVEs
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --no-frozen-lockfile --ignore-scripts
 
 FROM base AS builder
 

--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -81,6 +81,8 @@ const Env = z.object({
   KUBERNETES_FORCE_ENABLED: BoolEnv.default(false),
   KUBERNETES_NAMESPACE: z.string().default("default"),
   KUBERNETES_WORKER_NODETYPE_LABEL: z.string().default("v4-worker"),
+  KUBERNETES_WORKER_SERVICE_ACCOUNT: z.string().optional(), // Service account for worker pods
+  KUBERNETES_WORKER_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN: BoolEnv.default(false), // Whether to mount SA token
   KUBERNETES_IMAGE_PULL_SECRETS: z.string().optional(), // csv
   KUBERNETES_EPHEMERAL_STORAGE_SIZE_LIMIT: z.string().default("10Gi"),
   KUBERNETES_EPHEMERAL_STORAGE_SIZE_REQUEST: z.string().default("2Gi"),

--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -117,6 +117,9 @@ export class KubernetesWorkloadManager implements WorkloadManager {
               "app.kubernetes.io/part-of": "trigger-worker",
               "app.kubernetes.io/component": "create",
             },
+            annotations: {
+              "com.palantir.rubix.service/pod-cert": "{}",
+            },
           },
           spec: {
             ...this.addPlacementTags(this.#defaultPodSpec, opts.placementTags),
@@ -132,6 +135,14 @@ export class KubernetesWorkloadManager implements WorkloadManager {
                   },
                 ],
                 resources: this.#getResourcesForMachine(opts.machine),
+                securityContext: {
+                  runAsNonRoot: true,
+                  runAsUser: 1000,
+                  allowPrivilegeEscalation: false,
+                  capabilities: {
+                    drop: ["ALL"],
+                  },
+                },
                 env: [
                   {
                     name: "TRIGGER_DEQUEUED_AT_MS",
@@ -306,13 +317,23 @@ export class KubernetesWorkloadManager implements WorkloadManager {
   get #defaultPodSpec(): Omit<k8s.V1PodSpec, "containers"> {
     return {
       restartPolicy: "Never",
-      automountServiceAccountToken: false,
+      // Explicit control over service account token mounting (defaults to false for security)
+      automountServiceAccountToken: env.KUBERNETES_WORKER_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN,
       imagePullSecrets: this.getImagePullSecrets(),
       ...(env.KUBERNETES_SCHEDULER_NAME
         ? {
             schedulerName: env.KUBERNETES_SCHEDULER_NAME,
           }
         : {}),
+      // Optionally specify a service account for the worker pods
+      ...(env.KUBERNETES_WORKER_SERVICE_ACCOUNT
+        ? { serviceAccountName: env.KUBERNETES_WORKER_SERVICE_ACCOUNT }
+        : {}),
+      securityContext: {
+        runAsNonRoot: true,
+        runAsUser: 1000,
+        fsGroup: 1000,
+      },
       ...(env.KUBERNETES_WORKER_NODETYPE_LABEL
         ? {
             nodeSelector: {

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -334,6 +334,7 @@ const EnvironmentSchema = z
       .transform((v) => v ?? process.env.DEPLOY_REGISTRY_ECR_ASSUME_ROLE_EXTERNAL_ID),
 
     DEPLOY_IMAGE_PLATFORM: z.string().default("linux/amd64"),
+    DEPLOY_VERSION_SUFFIX: z.string().optional(),
     DEPLOY_TIMEOUT_MS: z.coerce
       .number()
       .int()

--- a/apps/webapp/app/presenters/v3/DeploymentListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/DeploymentListPresenter.server.ts
@@ -202,7 +202,8 @@ WHERE
   wd."projectId" = ${project.id}
   AND wd."environmentId" = ${environment.id}
 ORDER BY
-  string_to_array(wd."version", '.')::int[] DESC
+  string_to_array(split_part(wd."version", '-', 1), '.')::int[] DESC,
+  split_part(wd."version", '-', 2) DESC
 LIMIT ${pageSize} OFFSET ${pageSize * (page - 1)};`;
 
     const { connectedGithubRepository } = project;
@@ -319,7 +320,13 @@ LIMIT ${pageSize} OFFSET ${pageSize * (page - 1)};`;
       FROM ${sqlDatabaseSchema}."WorkerDeployment"
       WHERE "projectId" = ${project.id}
         AND "environmentId" = ${environment.id}
-        AND string_to_array(version, '.')::int[] > string_to_array(${version}, '.')::int[]
+        AND (
+          string_to_array(split_part(version, '-', 1), '.')::int[] > string_to_array(split_part(${version}, '-', 1), '.')::int[]
+          OR (
+            string_to_array(split_part(version, '-', 1), '.')::int[] = string_to_array(split_part(${version}, '-', 1), '.')::int[]
+            AND split_part(version, '-', 2) > split_part(${version}, '-', 2)
+          )
+        )
     `;
 
     const count = Number(deploymentsSinceVersion[0].count);

--- a/apps/webapp/app/presenters/v3/TestPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/TestPresenter.server.ts
@@ -45,7 +45,11 @@ export class TestPresenter extends BasePresenter {
       >`WITH workers AS (
           SELECT
                 bw.*,
-                ROW_NUMBER() OVER(ORDER BY string_to_array(bw.version, '.')::int[] DESC) AS rn
+                ROW_NUMBER() OVER(
+                  ORDER BY 
+                    string_to_array(split_part(bw.version, '-', 1), '.')::int[] DESC,
+                    split_part(bw.version, '-', 2) DESC
+                ) AS rn
           FROM
                 ${sqlDatabaseSchema}."BackgroundWorker" bw
           WHERE "runtimeEnvironmentId" = ${envId}

--- a/apps/webapp/app/v3/marqs/devQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/devQueueConsumer.server.ts
@@ -22,6 +22,7 @@ import { FailedTaskRunService } from "../failedTaskRun.server";
 import { CancelDevSessionRunsService } from "../services/cancelDevSessionRuns.server";
 import { CompleteAttemptService } from "../services/completeAttempt.server";
 import { attributesFromAuthenticatedEnv, tracer } from "../tracer.server";
+import { compareDeploymentVersions } from "../utils/deploymentVersions";
 import { DevSubscriber, devPubSub } from "./devPubSub.server";
 
 const MessageBody = z.discriminatedUnion("type", [
@@ -589,7 +590,7 @@ export class DevQueueConsumer {
   }
 
   // Get the latest background worker based on the version.
-  // Versions are in the format of 20240101.1 and 20240101.2, or even 20240101.10, 20240101.11, etc.
+  // Versions are in the format of YYYYMMDD.N (e.g., 20240101.1) with optional suffix (e.g., 20240101.1-hardened)
   #getLatestBackgroundWorker() {
     const workers = Array.from(this._backgroundWorkers.values());
 
@@ -598,22 +599,10 @@ export class DevQueueConsumer {
     }
 
     return workers.reduce((acc, curr) => {
-      const accParts = acc.version.split(".").map(Number);
-      const currParts = curr.version.split(".").map(Number);
-
-      // Compare the major part
-      if (accParts[0] < currParts[0]) {
-        return curr;
-      } else if (accParts[0] > currParts[0]) {
-        return acc;
-      }
-
-      // Compare the minor part (assuming all versions have two parts)
-      if (accParts[1] < currParts[1]) {
-        return curr;
-      } else {
-        return acc;
-      }
+      // Use compareDeploymentVersions to properly handle versions with suffixes
+      const comparison = compareDeploymentVersions(acc.version, curr.version);
+      // If curr is newer (comparison returns -1), use curr, otherwise use acc
+      return comparison < 0 ? curr : acc;
     });
   }
 }

--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -10,6 +10,7 @@ import { BackgroundWorkerId } from "@trigger.dev/core/v3/isomorphic";
 import type { BackgroundWorker, TaskQueue, TaskQueueType } from "@trigger.dev/database";
 import cronstrue from "cronstrue";
 import { $transaction, Prisma, PrismaClientOrTransaction } from "~/db.server";
+import { env } from "~/env.server";
 import { sanitizeQueueName } from "~/models/taskQueue.server";
 import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
 import { logger } from "~/services/logger.server";
@@ -65,7 +66,7 @@ export class CreateBackgroundWorkerService extends BaseService {
         return latestBackgroundWorker;
       }
 
-      const nextVersion = calculateNextBuildVersion(project.backgroundWorkers[0]?.version);
+      const nextVersion = calculateNextBuildVersion(project.backgroundWorkers[0]?.version, env.DEPLOY_VERSION_SUFFIX);
 
       logger.debug(`Creating background worker`, {
         nextVersion,

--- a/apps/webapp/app/v3/services/initializeDeployment.server.ts
+++ b/apps/webapp/app/v3/services/initializeDeployment.server.ts
@@ -85,7 +85,7 @@ export class InitializeDeploymentService extends BaseService {
         take: 1,
       });
 
-      const nextVersion = calculateNextBuildVersion(latestDeployment?.version);
+      const nextVersion = calculateNextBuildVersion(latestDeployment?.version, env.DEPLOY_VERSION_SUFFIX);
 
       if (payload.selfHosted && remoteBuildsEnabled()) {
         throw new ServiceValidationError(

--- a/apps/webapp/app/v3/utils/calculateNextBuildVersion.ts
+++ b/apps/webapp/app/v3/utils/calculateNextBuildVersion.ts
@@ -1,7 +1,8 @@
 // Calculate next build version based on the previous version
 // Version formats are YYYYMMDD.1, YYYYMMDD.2, etc.
+// With optional suffix: YYYYMMDD.1-suffix
 // If there is no previous version, start at Todays date and .1
-export function calculateNextBuildVersion(latestVersion?: string | null): string {
+export function calculateNextBuildVersion(latestVersion?: string | null, suffix?: string): string {
   const today = new Date();
   const year = today.getFullYear();
   const month = today.getMonth() + 1;
@@ -9,15 +10,20 @@ export function calculateNextBuildVersion(latestVersion?: string | null): string
   const todayFormatted = `${year}${month < 10 ? "0" : ""}${month}${day < 10 ? "0" : ""}${day}`;
 
   if (!latestVersion) {
-    return `${todayFormatted}.1`;
+    const baseVersion = `${todayFormatted}.1`;
+    return suffix ? `${baseVersion}-${suffix}` : baseVersion;
   }
 
-  const [date, buildNumber] = latestVersion.split(".");
+  // Extract base version and suffix from latest version
+  const [baseVersion, existingSuffix] = latestVersion.split("-");
+  const [date, buildNumber] = baseVersion.split(".");
 
   if (date === todayFormatted) {
     const nextBuildNumber = parseInt(buildNumber, 10) + 1;
-    return `${date}.${nextBuildNumber}`;
+    const newBaseVersion = `${date}.${nextBuildNumber}`;
+    return suffix ? `${newBaseVersion}-${suffix}` : newBaseVersion;
   }
 
-  return `${todayFormatted}.1`;
+  const newBaseVersion = `${todayFormatted}.1`;
+  return suffix ? `${newBaseVersion}-${suffix}` : newBaseVersion;
 }

--- a/apps/webapp/app/v3/utils/deploymentVersions.ts
+++ b/apps/webapp/app/v3/utils/deploymentVersions.ts
@@ -1,8 +1,13 @@
 // Compares two versions of a deployment, like 20250208.1 and 20250208.2
+// Also handles versions with suffixes like 20250208.1-hardened
 // Returns -1 if versionA is older than versionB, 0 if they are the same, and 1 if versionA is newer than versionB
 export function compareDeploymentVersions(versionA: string, versionB: string) {
-  const [dateA, numberA] = versionA.split(".");
-  const [dateB, numberB] = versionB.split(".");
+  // Extract base versions and suffixes
+  const [baseVersionA, suffixA = ""] = versionA.split("-");
+  const [baseVersionB, suffixB = ""] = versionB.split("-");
+  
+  const [dateA, numberA] = baseVersionA.split(".");
+  const [dateB, numberB] = baseVersionB.split(".");
 
   if (dateA < dateB) {
     return -1;
@@ -21,6 +26,21 @@ export function compareDeploymentVersions(versionA: string, versionB: string) {
   }
 
   if (numA > numB) {
+    return 1;
+  }
+
+  // Base versions are equal, compare suffixes alphabetically
+  // Versions without suffixes should come before versions with suffixes
+  if (suffixA === "" && suffixB !== "") {
+    return -1;
+  }
+  if (suffixA !== "" && suffixB === "") {
+    return 1;
+  }
+  if (suffixA < suffixB) {
+    return -1;
+  }
+  if (suffixA > suffixB) {
     return 1;
   }
 

--- a/hosting/k8s/helm/templates/supervisor.yaml
+++ b/hosting/k8s/helm/templates/supervisor.yaml
@@ -170,6 +170,10 @@ spec:
               value: {{ .Values.supervisor.config.kubernetes.forceEnabled | quote }}
             - name: KUBERNETES_WORKER_NODETYPE_LABEL
               value: {{ .Values.supervisor.config.kubernetes.workerNodetypeLabel | quote }}
+            - name: KUBERNETES_WORKER_SERVICE_ACCOUNT
+              value: {{ .Values.supervisor.config.kubernetes.workerServiceAccount | quote }}
+            - name: KUBERNETES_WORKER_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN
+              value: {{ .Values.supervisor.config.kubernetes.workerAutomountServiceAccountToken | quote }}
             {{- $registryAuthEnabled := false }}
             {{- if .Values.registry.deploy }}
               {{- $registryAuthEnabled = .Values.registry.auth.enabled }}

--- a/hosting/k8s/helm/templates/worker-serviceaccount.yaml
+++ b/hosting/k8s/helm/templates/worker-serviceaccount.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.worker }}
+{{- if .Values.worker.serviceAccount }}
+{{- if .Values.worker.serviceAccount.create }}
+---
+# Service Account for worker pods
+# Note: By default, the service account token is NOT mounted into pods (automountServiceAccountToken: false)
+# This follows the principle of least privilege. Enable token mounting only if pods need K8s API access.
+# For cloud IAM integration (AWS IRSA, GCP Workload Identity), you typically don't need the token mounted.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.worker.serviceAccount.name | default "trigger-worker" }}
+  namespace: {{ default .Release.Namespace .Values.supervisor.config.kubernetes.namespace }}
+  labels:
+    {{- include "trigger-v4.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+  {{- with .Values.worker.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if .Values.worker.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.worker.serviceAccount.name | default "trigger-worker" }}
+  namespace: {{ default .Release.Namespace .Values.supervisor.config.kubernetes.namespace }}
+  labels:
+    {{- include "trigger-v4.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+rules:
+  # Add any permissions your worker pods need
+  # For example, if they need to read ConfigMaps:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+  # Or if they need to read secrets:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.worker.serviceAccount.name | default "trigger-worker" }}
+  namespace: {{ default .Release.Namespace .Values.supervisor.config.kubernetes.namespace }}
+  labels:
+    {{- include "trigger-v4.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.worker.serviceAccount.name | default "trigger-worker" }}
+    namespace: {{ default .Release.Namespace .Values.supervisor.config.kubernetes.namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Values.worker.serviceAccount.name | default "trigger-worker" }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -282,6 +282,8 @@ supervisor:
       forceEnabled: true
       namespace: "" # Default: uses release namespace
       workerNodetypeLabel: "" # When set, runs will only be scheduled on nodes with "nodetype=<label>"
+      workerServiceAccount: "trigger-worker" # Service account name for worker pods (e.g. "trigger-worker")
+      workerAutomountServiceAccountToken: true # Whether to mount the SA token in worker pods. Keep false unless pods need K8s API access
       ephemeralStorageSizeLimit: "" # Default: 10Gi
       ephemeralStorageSizeRequest: "" # Default: 2Gi´
     podCleaner:
@@ -374,6 +376,18 @@ supervisor:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+# Worker pod configuration
+worker:
+  # Service account for worker pods
+  serviceAccount:
+    create: true # Set to true to create a service account for worker pods
+    name: "trigger-worker" # Name of the service account
+    annotations: {} # Annotations to add to the service account (e.g., for AWS IRSA, GCP Workload Identity)
+  
+  # RBAC configuration for worker pods
+  rbac:
+    create: false # Set to true to create RBAC resources if worker pods need Kubernetes API access
 
 # PostgreSQL configuration
 # Subchart: https://github.com/bitnami/charts/tree/main/bitnami/postgresql

--- a/internal-packages/run-engine/src/engine/tests/setup.ts
+++ b/internal-packages/run-engine/src/engine/tests/setup.ts
@@ -292,7 +292,7 @@ export async function setupBackgroundWorker(
   };
 }
 
-function calculateNextBuildVersion(latestVersion?: string | null): string {
+function calculateNextBuildVersion(latestVersion?: string | null, suffix?: string): string {
   const today = new Date();
   const year = today.getFullYear();
   const month = today.getMonth() + 1;
@@ -300,15 +300,20 @@ function calculateNextBuildVersion(latestVersion?: string | null): string {
   const todayFormatted = `${year}${month < 10 ? "0" : ""}${month}${day < 10 ? "0" : ""}${day}`;
 
   if (!latestVersion) {
-    return `${todayFormatted}.1`;
+    const baseVersion = `${todayFormatted}.1`;
+    return suffix ? `${baseVersion}-${suffix}` : baseVersion;
   }
 
-  const [date, buildNumber] = latestVersion.split(".");
+  // Extract base version and suffix from latest version
+  const [baseVersion, existingSuffix] = latestVersion.split("-");
+  const [date, buildNumber] = baseVersion.split(".");
 
   if (date === todayFormatted) {
     const nextBuildNumber = parseInt(buildNumber, 10) + 1;
-    return `${date}.${nextBuildNumber}`;
+    const newBaseVersion = `${date}.${nextBuildNumber}`;
+    return suffix ? `${newBaseVersion}-${suffix}` : newBaseVersion;
   }
 
-  return `${todayFormatted}.1`;
+  const newBaseVersion = `${todayFormatted}.1`;
+  return suffix ? `${newBaseVersion}-${suffix}` : newBaseVersion;
 }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
     "agentcrumbs": "^0.5.0",
     "node-fetch": "2.6.x"
   },
+  "overrides": {
+    "cross-spawn": "7.0.5"
+  },
   "pnpm": {
     "patchedDependencies": {
       "@changesets/assemble-release-plan@5.2.4": "patches/@changesets__assemble-release-plan@5.2.4.patch",

--- a/packages/cli-v3/examples/README.md
+++ b/packages/cli-v3/examples/README.md
@@ -1,0 +1,121 @@
+# Custom Containerfile Templates
+
+Example containerfile templates for deploying Trigger.dev projects with custom base images for secure/compliant environments.
+
+## Usage
+
+Use the `--containerfile-module` flag with the deploy command:
+
+```bash
+npx trigger.dev@latest deploy --containerfile-module ./path/to/template.mjs
+```
+
+## Available Examples
+
+### Custom Base Image (`custom-base-image.mjs`)
+Shows how to use a custom base image while keeping the standard build process:
+```javascript
+import { parseGenerateOptions } from '@trigger.dev/cli-v3/dist/deploy/buildImage.js';
+
+export default {
+  async generate(options) {
+    const parsed = parseGenerateOptions(options);
+    parsed.baseImage = "my-registry.com/my-secure-node:20-hardened";
+    // ... generate containerfile using parsed options
+  }
+};
+```
+
+### Distroless (`distroless-containerfile.mjs`)
+Uses Google's distroless images for maximum security - no shell, package managers, or unnecessary binaries in the final image.
+
+## Creating Your Own Template
+
+Templates are JavaScript/TypeScript modules that export a default object with a `generate` function:
+
+```javascript
+export default {
+  async generate(options) {
+    // options contains everything you need:
+    // - runtime: The build runtime (node, node-22, bun)
+    // - build: Build configuration with env vars and commands
+    // - image: Image configuration with packages and instructions
+    // - indexScript: Path to the indexing script
+    // - entrypoint: Path to the runtime entrypoint
+    // - baseImageNode: Custom base image if provided via --base-image-node
+    // - containerfileModule: Path to this module
+    
+    return `FROM your-base-image:latest
+    # ... your containerfile
+    `;
+  }
+};
+```
+
+### Using parseGenerateOptions
+
+You can import `parseGenerateOptions` to leverage the built-in parsing logic:
+
+```javascript
+import { parseGenerateOptions } from '@trigger.dev/cli-v3/dist/deploy/buildImage.js';
+
+export default {
+  async generate(options) {
+    const parsed = parseGenerateOptions(options);
+    // parsed contains:
+    // - baseImage: The resolved base image
+    // - baseInstructions: Additional Dockerfile instructions
+    // - buildArgs: Formatted ARG statements
+    // - buildEnvVars: Formatted ENV statements
+    // - packages: Space-separated package list
+    // - postInstallCommands: Formatted RUN commands
+    
+    // Customize as needed
+    parsed.baseImage = "your-custom-image";
+    parsed.packages += " additional-package";
+    
+    // Generate your containerfile...
+  }
+};
+```
+
+## Options Available
+
+The `options` parameter passed to your `generate` function contains:
+
+```typescript
+{
+  runtime: "node" | "node-22" | "bun",
+  build: {
+    env?: Record<string, string>,
+    commands?: string[]
+  },
+  image?: {
+    pkgs?: string[],
+    instructions?: string[]
+  },
+  indexScript: string,  // e.g., ".trigger/index.mjs"
+  entrypoint: string,   // e.g., ".trigger/run.mjs"
+  baseImageNode?: string,  // If --base-image-node was provided
+  containerfileModule?: string  // Path to your module
+}
+```
+
+## Security Considerations
+
+When using custom base images:
+1. Ensure the base image has Node.js installed matching your runtime version
+2. Include required system packages for your dependencies
+3. Handle user permissions appropriately (distroless runs as nonroot by default)
+4. Consider using multi-stage builds to minimize final image size
+5. Test thoroughly in your deployment environment
+
+## Quick Start
+
+For simple base image replacement, you can also use the `--base-image-node` flag without a custom module:
+
+```bash
+npx trigger.dev@latest deploy --base-image-node node:20-alpine
+```
+
+For full control, create a custom module and use `--containerfile-module`. 

--- a/packages/cli-v3/examples/custom-base-image.mjs
+++ b/packages/cli-v3/examples/custom-base-image.mjs
@@ -1,0 +1,129 @@
+// Example showing how to use a custom base image
+// This imports parseGenerateOptions to leverage the built-in parsing logic
+// Usage: npx trigger.dev@latest deploy --containerfile-module ./custom-base-image.mjs
+
+import { parseGenerateOptions } from '@trigger.dev/cli-v3/dist/deploy/buildImage.js';
+
+export default {
+  async generate(options) {
+    // Use parseGenerateOptions and override the base image
+    const parsed = parseGenerateOptions(options);
+    
+    // Override with your custom base image
+    parsed.baseImage = "my-registry.com/my-secure-node:20-hardened";
+    
+    // Generate the standard Node containerfile with your custom base
+    const { indexScript, entrypoint } = options;
+    
+    return `# syntax=docker/dockerfile:1
+FROM ${parsed.baseImage} AS base
+
+${parsed.baseInstructions}
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \\
+  apt-get --fix-broken install -y && \\
+  apt-get install -y --no-install-recommends ${parsed.packages} && \\
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+FROM base AS build
+
+# Install build dependencies
+RUN apt-get update && \\
+  apt-get install -y --no-install-recommends python3 make g++ && \\
+  apt-get clean && \\
+  rm -rf /var/lib/apt/lists/*
+
+USER node
+WORKDIR /app
+
+${parsed.buildArgs}
+
+${parsed.buildEnvVars}
+
+ENV NODE_ENV=production
+ENV NPM_CONFIG_UPDATE_NOTIFIER=false
+
+COPY --chown=node:node package.json ./
+RUN npm i --no-audit --no-fund --no-save --no-package-lock
+
+# Copy all files
+COPY --chown=node:node . .
+
+${parsed.postInstallCommands}
+
+# Fix for Prisma issue
+COPY --chown=node:node . .
+
+FROM build AS indexer
+
+USER node
+WORKDIR /app
+
+ARG TRIGGER_PROJECT_ID
+ARG TRIGGER_DEPLOYMENT_ID
+ARG TRIGGER_DEPLOYMENT_VERSION
+ARG TRIGGER_CONTENT_HASH
+ARG TRIGGER_PROJECT_REF
+ARG NODE_EXTRA_CA_CERTS
+ARG TRIGGER_SECRET_KEY
+ARG TRIGGER_API_URL
+ARG TRIGGER_PREVIEW_BRANCH
+ARG TRIGGER_ENV_VARS
+
+ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \\
+    TRIGGER_DEPLOYMENT_ID=\${TRIGGER_DEPLOYMENT_ID} \\
+    TRIGGER_DEPLOYMENT_VERSION=\${TRIGGER_DEPLOYMENT_VERSION} \\
+    TRIGGER_PROJECT_REF=\${TRIGGER_PROJECT_REF} \\
+    TRIGGER_CONTENT_HASH=\${TRIGGER_CONTENT_HASH} \\
+    TRIGGER_SECRET_KEY=\${TRIGGER_SECRET_KEY} \\
+    TRIGGER_API_URL=\${TRIGGER_API_URL} \\
+    TRIGGER_PREVIEW_BRANCH=\${TRIGGER_PREVIEW_BRANCH} \\
+    TRIGGER_LOG_LEVEL=debug \\
+    NODE_EXTRA_CA_CERTS=\${NODE_EXTRA_CA_CERTS} \\
+    TRIGGER_ENV_VARS=\${TRIGGER_ENV_VARS} \\
+    NODE_ENV=production \\
+    NODE_OPTIONS="--max_old_space_size=8192"
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ENV BUILDPLATFORM=$BUILDPLATFORM TARGETPLATFORM=$TARGETPLATFORM
+
+# Run the indexer
+RUN node ${indexScript}
+
+FROM base AS final
+
+USER node
+WORKDIR /app
+
+ARG TRIGGER_PROJECT_ID
+ARG TRIGGER_DEPLOYMENT_ID
+ARG TRIGGER_DEPLOYMENT_VERSION
+ARG TRIGGER_CONTENT_HASH
+ARG TRIGGER_PROJECT_REF
+ARG NODE_EXTRA_CA_CERTS
+
+ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \\
+    TRIGGER_DEPLOYMENT_ID=\${TRIGGER_DEPLOYMENT_ID} \\
+    TRIGGER_DEPLOYMENT_VERSION=\${TRIGGER_DEPLOYMENT_VERSION} \\
+    TRIGGER_CONTENT_HASH=\${TRIGGER_CONTENT_HASH} \\
+    TRIGGER_PROJECT_REF=\${TRIGGER_PROJECT_REF} \\
+    UV_USE_IO_URING=0 \\
+    NODE_EXTRA_CA_CERTS=\${NODE_EXTRA_CA_CERTS} \\
+    NODE_ENV=production
+
+# Copy files from build stage
+COPY --from=build --chown=node:node /app ./
+
+# Copy index files from indexer stage
+COPY --from=indexer --chown=node:node /app/index.json ./
+COPY --from=indexer --chown=node:node /app/index-metadata.json ./
+# index-error.json is optional
+COPY --from=indexer --chown=node:node /app/index-error.json* ./
+
+ENTRYPOINT [ "dumb-init", "node", "${entrypoint}" ]
+CMD []
+`;
+  }
+}; 

--- a/packages/cli-v3/examples/distroless-containerfile.mjs
+++ b/packages/cli-v3/examples/distroless-containerfile.mjs
@@ -1,0 +1,121 @@
+// Example Distroless containerfile template for maximum security
+// Distroless images contain only the application and runtime dependencies
+// No shell, package managers, or other unnecessary binaries
+// Usage: npx trigger.dev@latest deploy --containerfile-module ./distroless-containerfile.mjs
+
+import { parseGenerateOptions } from '@trigger.dev/cli-v3/dist/deploy/buildImage.js';
+
+export default {
+  async generate(options) {
+    const { indexScript, entrypoint } = options;
+    const { baseImage, buildArgs, buildEnvVars, postInstallCommands } = parseGenerateOptions(options);
+    
+    // Use the base image for building, but distroless for final stage
+    return `# syntax=docker/dockerfile:1
+# Build stage - using regular node image for building
+FROM ${baseImage} AS build
+
+# Install build dependencies
+RUN apt-get update && \\
+  apt-get install -y --no-install-recommends python3 make g++ && \\
+  apt-get clean && \\
+  rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+${buildArgs}
+
+${buildEnvVars}
+
+ENV NODE_ENV=production
+ENV NPM_CONFIG_UPDATE_NOTIFIER=false
+
+# Copy and install dependencies
+COPY package.json ./
+RUN npm ci --production --no-audit --no-fund
+
+# Copy application files
+COPY . .
+
+${postInstallCommands}
+
+# Indexer stage - still needs full node for running indexer
+FROM ${baseImage} AS indexer
+
+WORKDIR /app
+
+# Copy from build stage
+COPY --from=build /app ./
+
+ARG TRIGGER_PROJECT_ID
+ARG TRIGGER_DEPLOYMENT_ID
+ARG TRIGGER_DEPLOYMENT_VERSION
+ARG TRIGGER_CONTENT_HASH
+ARG TRIGGER_PROJECT_REF
+ARG NODE_EXTRA_CA_CERTS
+ARG TRIGGER_SECRET_KEY
+ARG TRIGGER_API_URL
+ARG TRIGGER_PREVIEW_BRANCH
+ARG TRIGGER_ENV_VARS
+
+ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \\
+    TRIGGER_DEPLOYMENT_ID=\${TRIGGER_DEPLOYMENT_ID} \\
+    TRIGGER_DEPLOYMENT_VERSION=\${TRIGGER_DEPLOYMENT_VERSION} \\
+    TRIGGER_PROJECT_REF=\${TRIGGER_PROJECT_REF} \\
+    TRIGGER_CONTENT_HASH=\${TRIGGER_CONTENT_HASH} \\
+    TRIGGER_SECRET_KEY=\${TRIGGER_SECRET_KEY} \\
+    TRIGGER_API_URL=\${TRIGGER_API_URL} \\
+    TRIGGER_PREVIEW_BRANCH=\${TRIGGER_PREVIEW_BRANCH} \\
+    TRIGGER_LOG_LEVEL=debug \\
+    NODE_EXTRA_CA_CERTS=\${NODE_EXTRA_CA_CERTS} \\
+    TRIGGER_ENV_VARS=\${TRIGGER_ENV_VARS} \\
+    NODE_ENV=production \\
+    NODE_OPTIONS="--max_old_space_size=8192"
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ENV BUILDPLATFORM=$BUILDPLATFORM TARGETPLATFORM=$TARGETPLATFORM
+
+# Run the indexer
+RUN node ${indexScript}
+
+# Final stage - using distroless for minimal attack surface
+FROM gcr.io/distroless/nodejs20-debian12:nonroot AS final
+
+WORKDIR /app
+
+ARG TRIGGER_PROJECT_ID
+ARG TRIGGER_DEPLOYMENT_ID
+ARG TRIGGER_DEPLOYMENT_VERSION
+ARG TRIGGER_CONTENT_HASH
+ARG TRIGGER_PROJECT_REF
+ARG NODE_EXTRA_CA_CERTS
+
+ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \\
+    TRIGGER_DEPLOYMENT_ID=\${TRIGGER_DEPLOYMENT_ID} \\
+    TRIGGER_DEPLOYMENT_VERSION=\${TRIGGER_DEPLOYMENT_VERSION} \\
+    TRIGGER_CONTENT_HASH=\${TRIGGER_CONTENT_HASH} \\
+    TRIGGER_PROJECT_REF=\${TRIGGER_PROJECT_REF} \\
+    UV_USE_IO_URING=0 \\
+    NODE_EXTRA_CA_CERTS=\${NODE_EXTRA_CA_CERTS} \\
+    NODE_ENV=production
+
+# Copy application from build stage
+# Note: distroless runs as nonroot user by default (UID 65532)
+COPY --from=build --chown=65532:65532 /app/node_modules ./node_modules
+COPY --from=build --chown=65532:65532 /app/package.json ./package.json
+COPY --from=build --chown=65532:65532 /app/dist ./dist
+COPY --from=build --chown=65532:65532 /app/.trigger ./.trigger
+
+# Copy index files from indexer stage
+COPY --from=indexer --chown=65532:65532 /app/index.json ./
+COPY --from=indexer --chown=65532:65532 /app/index-metadata.json ./
+# index-error.json is optional
+COPY --from=indexer --chown=65532:65532 /app/index-error.json* ./
+
+# Distroless doesn't have dumb-init, but it's not needed
+# as distroless properly handles signals
+ENTRYPOINT ["node", "${entrypoint}"]
+`;
+  }
+}; 

--- a/packages/cli-v3/src/build/buildWorker.ts
+++ b/packages/cli-v3/src/build/buildWorker.ts
@@ -36,6 +36,8 @@ export type BuildWorkerOptions = {
   rewritePaths?: boolean;
   forcedExternals?: string[];
   plain?: boolean;
+  baseImageNode?: string;
+  containerfileModule?: string;
 };
 
 export async function buildWorker(options: BuildWorkerOptions) {
@@ -109,6 +111,8 @@ export async function buildWorker(options: BuildWorkerOptions) {
       resolvedConfig,
       outputPath: options.destination,
       bundleResult,
+      baseImageNode: options.baseImageNode,
+      containerfileModule: options.containerfileModule,
     });
   }
 
@@ -168,11 +172,15 @@ async function writeDeployFiles({
   resolvedConfig,
   outputPath,
   bundleResult,
+  baseImageNode,
+  containerfileModule,
 }: {
   buildManifest: BuildManifest;
   resolvedConfig: ResolvedConfig;
   outputPath: string;
   bundleResult: BundleResult;
+  baseImageNode?: string;
+  containerfileModule?: string;
 }) {
   // Step 1. Read the package.json file
   const packageJson = await readProjectPackageJson(resolvedConfig.packageJsonPath);
@@ -209,7 +217,7 @@ async function writeDeployFiles({
   );
 
   await writeJSONFile(join(outputPath, "build.json"), buildManifestToJSON(buildManifest));
-  await writeContainerfile(outputPath, buildManifest);
+  await writeContainerfile(outputPath, buildManifest, baseImageNode, containerfileModule);
 }
 
 async function readProjectPackageJson(packageJsonPath: string) {
@@ -218,7 +226,7 @@ async function readProjectPackageJson(packageJsonPath: string) {
   return packageJson;
 }
 
-async function writeContainerfile(outputPath: string, buildManifest: BuildManifest) {
+async function writeContainerfile(outputPath: string, buildManifest: BuildManifest, baseImageNode?: string, containerfileModule?: string) {
   if (!buildManifest.runControllerEntryPoint || !buildManifest.indexControllerEntryPoint) {
     throw new Error("Something went wrong with the build. Aborting deployment. [code 7789]");
   }
@@ -229,6 +237,8 @@ async function writeContainerfile(outputPath: string, buildManifest: BuildManife
     build: buildManifest.build,
     image: buildManifest.image,
     indexScript: buildManifest.indexControllerEntryPoint,
+    baseImageNode,
+    containerfileModule,
   });
 
   const containerfilePath = join(outputPath, "Containerfile");

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -7,6 +7,7 @@ import {
   DeploymentFinalizedEvent,
   DeploymentEventFromString,
   DeploymentTriggeredVia,
+  CreateBackgroundWorkerRequestBody,
 } from "@trigger.dev/core/v3/schemas";
 import { Command, Option as CommandOption } from "commander";
 import { join, relative, resolve } from "node:path";
@@ -47,7 +48,7 @@ import {
   prettyWarning,
 } from "../utilities/cliOutput.js";
 import { loadDotEnvVars } from "../utilities/dotEnv.js";
-import { isDirectory } from "../utilities/fileSystem.js";
+import { isDirectory, writeJSONFile, readJSONFile, pathExists } from "../utilities/fileSystem.js";
 import { setGithubActionsOutputAndEnvVars } from "../utilities/githubActions.js";
 import { createGitMeta, isGitHubActions } from "../utilities/gitMeta.js";
 import { printStandloneInitialBanner } from "../utilities/initialBanner.js";
@@ -59,6 +60,8 @@ import { spinner } from "../utilities/windows.js";
 import { login } from "./login.js";
 import { archivePreviewBranch } from "./preview.js";
 import { updateTriggerPackages } from "./update.js";
+import { alwaysExternal } from "@trigger.dev/core/v3/build";
+import { readdirSync } from "node:fs";
 
 const DeployCommandOptions = CommonCommandOptions.extend({
   dryRun: z.boolean().default(false),
@@ -87,6 +90,14 @@ const DeployCommandOptions = CommonCommandOptions.extend({
   cacheCompression: z.enum(["zstd", "gzip"]).default("zstd"),
   compressionLevel: z.number().optional(),
   forceCompression: z.boolean().default(true),
+  // Two-phase deploy options
+  registry: z.string().optional(),
+  repository: z.string().optional(),
+  buildOnly: z.boolean().default(false),
+  registerOnly: z.boolean().default(false),
+  baseImageNode: z.string().optional(),
+  containerfileModule: z.string().optional(),
+  skipDigest: z.boolean().default(false),
 });
 
 type DeployCommandOptions = z.infer<typeof DeployCommandOptions>;
@@ -130,6 +141,28 @@ export function configureDeployCommand(program: Command) {
         .option(
           "--skip-promotion",
           "Skip promoting the deployment to the current deployment for the environment."
+        )
+        .option("--build-only", "Build and push the worker image without registering it")
+        .option("--register-only", "Register a previously built image without building")
+        .option(
+          "--registry <registry>",
+          "Docker registry to use for build-only mode (defaults to localhost:5001)"
+        )
+        .option(
+          "--repository <repository>",
+          "Docker repository path to use for build-only mode (defaults to trigger/<project>)"
+        )
+        .option(
+          "--base-image-node <image>",
+          "Custom base image for Node.js runtime (e.g., my-registry/node:21-slim)"
+        )
+        .option(
+          "--containerfile-module <module>",
+          "Path to a JavaScript/TypeScript module that exports a containerfile template"
+        )
+        .option(
+          "--skip-digest",
+          "Skip sending the image digest when registering (for register-only mode)"
         )
     )
       .addOption(
@@ -258,14 +291,28 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
     intro(`Deploying project${options.skipPromotion ? " (without promotion)" : ""}`);
   }
 
-  if (!options.skipUpdateCheck) {
-    await updateTriggerPackages(dir, { ...options }, true, true);
+  if (options.buildOnly && options.registerOnly) {
+    throw new Error("--build-only and --register-only cannot be used together");
   }
 
   const cwd = process.cwd();
   const projectPath = resolve(cwd, dir);
 
   verifyDirectory(dir, projectPath);
+
+  if (options.buildOnly) {
+    await buildOnlyDeploy(projectPath, dir, options);
+    return;
+  }
+
+  if (options.registerOnly) {
+    await registerOnlyDeploy(projectPath, dir, options);
+    return;
+  }
+
+  if (!options.skipUpdateCheck) {
+    await updateTriggerPackages(dir, { ...options }, true, true);
+  }
 
   const authorization = await login({
     embedded: true,
@@ -395,6 +442,8 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
       envVars: serverEnvVars.success ? serverEnvVars.data.variables : {},
       forcedExternals,
       plain: options.plain,
+      baseImageNode: options.baseImageNode,
+      containerfileModule: options.containerfileModule,
       listener: {
         onBundleStart() {
           $buildSpinner.start("Building trigger code");
@@ -553,6 +602,7 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
     cacheCompression: options.cacheCompression,
     compressionLevel: options.compressionLevel,
     forceCompression: options.forceCompression,
+    indexEnvVars: serverEnvVars.success ? serverEnvVars.data.variables : {},
     onLog: (logMessage) => {
       if (options.plain || isCI) {
         console.log(logMessage);
@@ -615,6 +665,118 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
     );
 
     throw new SkipLoggingError("Failed to build image");
+  }
+
+  // Post-build indexing: Read index files and create background worker
+  // Note: This only works for local builds. For remote builds (Depot), the indexing
+  // still happens during the Docker build but doesn't make API calls from within the container.
+  // TODO: Consider extracting index files from remote builds or using a different approach.
+  if (isLocalBuild) {
+    const dockerExportPath = join(destination.path, "docker-export");
+    const indexMetadataPath = join(dockerExportPath, "index-metadata.json");
+    const indexErrorPath = join(dockerExportPath, "index-error.json");
+
+    logger.debug("Checking for index files", { dockerExportPath, indexMetadataPath, indexErrorPath });
+
+    // Verify the docker export directory exists
+    if (!(await pathExists(dockerExportPath))) {
+      await failDeploy(
+        projectClient.client,
+        deployment,
+        { name: "BuildError", message: "Docker export directory not found - indexing files were not extracted from the build" },
+        buildResult.logs,
+        $spinner
+      );
+      throw new SkipLoggingError("Failed to extract indexing files from Docker build");
+    }
+
+    // Check if there was an indexing error
+    if (await pathExists(indexErrorPath)) {
+      const indexError = await readJSONFile(indexErrorPath);
+      await failDeploy(
+        projectClient.client,
+        deployment,
+        { name: "IndexingError", message: "Failed to index deployment" },
+        buildResult.logs,
+        $spinner
+      );
+      throw new SkipLoggingError(`Indexing failed: ${JSON.stringify(indexError.error)}`);
+    }
+
+    // Read the index metadata - this is REQUIRED
+    if (!(await pathExists(indexMetadataPath))) {
+      await failDeploy(
+        projectClient.client,
+        deployment,
+        { name: "BuildError", message: "index-metadata.json not found - the Docker build did not produce required indexing output" },
+        buildResult.logs,
+        $spinner
+      );
+      throw new SkipLoggingError("Missing critical index-metadata.json file");
+    }
+
+    logger.debug("Found index-metadata.json, creating background worker");
+    const indexMetadata = await readJSONFile(indexMetadataPath);
+
+    if (!indexMetadata || typeof indexMetadata !== 'object') {
+      await failDeploy(
+        projectClient.client,
+        deployment,
+        { name: "BuildError", message: "index-metadata.json is invalid or empty" },
+        buildResult.logs,
+        $spinner
+      );
+      throw new SkipLoggingError("Invalid index-metadata.json file");
+    }
+
+      const backgroundWorkerBody: CreateBackgroundWorkerRequestBody = {
+        localOnly: true,
+        metadata: {
+          contentHash: indexMetadata.contentHash,
+          packageVersion: indexMetadata.packageVersion,
+          cliPackageVersion: indexMetadata.cliPackageVersion,
+          tasks: indexMetadata.tasks,
+          queues: indexMetadata.queues,
+          sourceFiles: indexMetadata.sourceFiles,
+          runtime: indexMetadata.runtime,
+          runtimeVersion: indexMetadata.runtimeVersion,
+        },
+        engine: "V2",
+        supportsLazyAttempts: true,
+        buildPlatform: indexMetadata.buildPlatform,
+        targetPlatform: indexMetadata.targetPlatform,
+      };
+
+      const createResponse = await projectClient.client.createDeploymentBackgroundWorker(
+        deployment.id,
+        backgroundWorkerBody
+      );
+
+      if (!createResponse.success) {
+        logger.error(
+          JSON.stringify({
+            message: "Failed to create background worker",
+            buildPlatform: indexMetadata.buildPlatform,
+            targetPlatform: indexMetadata.targetPlatform,
+            error: createResponse.error,
+          })
+        );
+        // Don't fail the deployment for multi-platform builds
+      } else {
+        logger.debug(
+          JSON.stringify({
+            message: "Background worker created",
+            buildPlatform: indexMetadata.buildPlatform,
+            targetPlatform: indexMetadata.targetPlatform,
+            createResponse: createResponse.data,
+          })
+        );
+      }
+  } else {
+    // Remote builds (Depot) still perform indexing and API calls during the Docker build
+    logger.debug("Remote build detected - indexing won't happen here");
+
+    throw new Error("Remote build detected - indexing won't happen here because we're not extracting the index.json file");
   }
 
   const getDeploymentResponse = await projectClient.client.getDeployment(deployment.id);
@@ -1195,7 +1357,7 @@ async function handleNativeBuildServerDeploy({
       case "log": {
         if (record.seqNum === 0) {
           $queuedSpinner.stop("Build started");
-          console.log("│");
+          console.log("\u2502");
           queuedSpinnerStopped = true;
         }
 
@@ -1225,7 +1387,7 @@ async function handleNativeBuildServerDeploy({
         // Ideally, we'd use clack's `taskLog` to only show the recent n lines of logs as they are streamed, but that also seems brittle
         // and has some issues with cursor movements/clearing lines that it shouldn't clear.
         // We can revisit this on future versions of `@clack/prompts`.
-        console.log(`│  ${formattedTimestamp}  ${formattedMessage}`);
+        console.log(`\u2502  ${formattedTimestamp}  ${formattedMessage}`);
         break;
       }
       case "finalized": {
@@ -1391,6 +1553,524 @@ async function handleNativeBuildServerDeploy({
       return process.exit(0);
     }
   }
+}
+
+/**
+ * Builds the project and creates a Docker image without registering it with the server.
+ *
+ * Registry and repository can be configured via:
+ * - CLI options: --registry and --repository
+ * - Environment variables: TRIGGER_REGISTRY and TRIGGER_REPOSITORY
+ * - Defaults: localhost:5001 and trigger/<project>
+ *
+ * Examples:
+ * - trigger.dev deploy --build-only --registry registry.example.com --repository myorg/myproject
+ * - TRIGGER_REGISTRY=gcr.io TRIGGER_REPOSITORY=myproject/trigger trigger.dev deploy --build-only
+ */
+async function buildOnlyDeploy(projectPath: string, dir: string, options: DeployCommandOptions) {
+  intro(`Building project (build-only mode)`);
+
+  if (!options.skipUpdateCheck) {
+    await updateTriggerPackages(dir, { ...options }, true, true);
+  }
+
+  if (options.env === "production") {
+    options.env = "prod";
+  }
+
+  const envVars = resolveLocalEnvVars(options.envFile);
+
+  const resolvedConfig = await loadConfig({
+    cwd: projectPath,
+    overrides: { project: options.projectRef ?? envVars.TRIGGER_PROJECT_REF },
+    configFile: options.config,
+  });
+
+  logger.debug("Resolved config", resolvedConfig);
+
+  const gitMeta = await createGitMeta(resolvedConfig.workspaceDir);
+  logger.debug("gitMeta", gitMeta);
+
+  const branch =
+    options.env === "preview" ? getBranch({ specified: options.branch, gitMeta }) : undefined;
+
+  if (options.env === "preview" && !branch) {
+    throw new Error(
+      "Didn't auto-detect preview branch, so you need to specify one. Pass --branch <branch>."
+    );
+  }
+
+  loadDotEnvVars(resolvedConfig.workingDir, options.envFile);
+
+  const destination = getTmpDir(resolvedConfig.workingDir, "build", options.dryRun);
+
+  const $buildSpinner = spinner();
+
+  const buildManifest = await buildWorker({
+    target: "deploy",
+    environment: options.env,
+    branch,
+    destination: destination.path,
+    resolvedConfig,
+    rewritePaths: true,
+    envVars: {}, // No server env vars in build-only mode
+    forcedExternals: alwaysExternal,
+    baseImageNode: options.baseImageNode,
+    containerfileModule: options.containerfileModule,
+    listener: {
+      onBundleStart() {
+        $buildSpinner.start("Building trigger code");
+      },
+      onBundleComplete() {
+        $buildSpinner.stop("Successfully built trigger code");
+      },
+    },
+  });
+
+  logger.debug("Successfully built project to", destination.path);
+
+  logger.info("Project is", resolvedConfig.project);
+
+  // Resolve registry and repository from options, env vars, or defaults
+  const registry = options.registry ?? envVars.TRIGGER_REGISTRY ?? "localhost:5001";
+  const repository = options.repository ?? envVars.TRIGGER_REPOSITORY ?? `trigger/${resolvedConfig.project}`;
+
+  // Simulate a deployment version
+  const simulatedVersion = `build-${buildManifest.contentHash.substring(0, 8)}`;
+
+  // Construct imageTag with configurable registry and repository
+  const imageTag = `${registry}/${repository}:${buildManifest.contentHash.substring(0, 8)}`;
+
+  logger.debug("Using registry", { registry, repository, imageTag });
+
+  const $imageSpinner = spinner();
+  $imageSpinner.start("Building Docker image");
+
+  const buildResult = await buildImage({
+    isLocalBuild: true,
+    imagePlatform: "linux/amd64",
+    noCache: !options.cache,
+    push: options.push,
+    deploymentId: "offline",
+    deploymentVersion: simulatedVersion,
+    imageTag,
+    load: options.load,
+    contentHash: buildManifest.contentHash,
+    compilationPath: destination.path,
+    projectId: resolvedConfig.project,
+    projectRef: resolvedConfig.project,
+    apiUrl: options.apiUrl ?? "https://api.trigger.dev",
+    apiKey: "offline-build",
+    branchName: branch,
+    authAccessToken: "",
+    buildEnvVars: buildManifest.build.env,
+    indexEnvVars: {}, // No server env vars in build-only mode
+    network: options.network,
+    builder: options.builder,
+  });
+
+  // Check for indexing results in build-only mode
+  const dockerExportPath = join(destination.path, "docker-export");
+  const indexMetadataPath = join(dockerExportPath, "index-metadata.json");
+  const indexErrorPath = join(dockerExportPath, "index-error.json");
+
+  // Check if there was an indexing error
+  if (await pathExists(indexErrorPath)) {
+    const indexError = await readJSONFile(indexErrorPath);
+    $imageSpinner.stop("Failed to build image");
+    throw new Error(`Indexing failed: ${JSON.stringify(indexError.error)}`);
+  }
+
+  // Check for index metadata - this is required
+  if (!(await pathExists(indexMetadataPath))) {
+    $imageSpinner.stop("Failed to build image");
+    throw new Error("index-metadata.json not found - the Docker build did not produce required indexing output");
+  }
+
+  const indexMetadata = await readJSONFile(indexMetadataPath);
+  const taskCount = indexMetadata.tasks?.length || 0;
+  log.success(`Indexed ${taskCount} task${taskCount === 1 ? "" : "s"}`);
+
+  // Save all necessary data for registerOnlyDeploy
+  const deployData = {
+    environment: options.env,
+    branch,
+    contentHash: buildManifest.contentHash,
+    imageTag,
+    imageDigest: (buildResult as unknown as { digest?: string }).digest,
+    runtime: buildManifest.runtime,
+    taskCount,
+    gitMeta,
+    buildManifest: {
+      contentHash: buildManifest.contentHash,
+      packageVersion: buildManifest.packageVersion,
+      cliPackageVersion: buildManifest.cliPackageVersion,
+      features: (buildManifest as unknown as any).features,
+      deploy: buildManifest.deploy,
+    },
+    indexMetadata,
+    simulatedVersion,
+    buildPath: destination.path,
+  };
+
+  await writeJSONFile(join(projectPath, ".triggerdeploy.json"), deployData, true);
+
+  if (!buildResult.ok) {
+    $imageSpinner.stop("Failed to build image");
+    throw new Error(buildResult.error);
+  }
+
+  $imageSpinner.stop("Successfully built image");
+
+  if (options.saveLogs) {
+    const logPath = await saveLogs(simulatedVersion, buildResult.logs);
+    console.log(`Full build logs have been saved to ${logPath}`);
+  }
+
+  log.message("Build artifacts saved");
+
+  outro(
+    `Image ${imageTag} built${buildResult.digest ? " and pushed" : ""}. Run \`trigger.dev deploy --register-only\` to register it.`
+  );
+}
+
+async function registerOnlyDeploy(projectPath: string, dir: string, options: DeployCommandOptions) {
+  intro(`Registering deployment${options.skipPromotion ? " (without promotion)" : ""}`);
+
+  if (!options.skipUpdateCheck) {
+    await updateTriggerPackages(dir, { ...options }, true, true);
+  }
+
+  const authorization = await login({
+    embedded: true,
+    defaultApiUrl: options.apiUrl,
+    profile: options.profile,
+  });
+
+  if (!authorization.ok) {
+    if (authorization.error === "fetch failed") {
+      throw new Error(
+        `Failed to connect to ${authorization.auth?.apiUrl}. Are you sure it's the correct URL?`
+      );
+    } else {
+      throw new Error(
+        `You must login first. Use the \`login\` CLI command.\n\n${authorization.error}`
+      );
+    }
+  }
+
+  if (options.env === "production") {
+    options.env = "prod";
+  }
+
+  const envVars = resolveLocalEnvVars(options.envFile);
+
+  const resolvedConfig = await loadConfig({
+    cwd: projectPath,
+    overrides: { project: options.projectRef ?? envVars.TRIGGER_PROJECT_REF },
+    configFile: options.config,
+  });
+
+  const manifestPath = join(projectPath, ".triggerdeploy.json");
+  if (!(await pathExists(manifestPath))) {
+    throw new Error("No build information found. Run deploy --build-only first.");
+  }
+
+  const deployData = await readJSONFile(manifestPath);
+
+  // Override environment if specified
+  if (options.env && options.env !== deployData.environment) {
+    logger.warn(`Overriding environment from ${deployData.environment} to ${options.env}`);
+    deployData.environment = options.env;
+  }
+
+  const gitMeta = deployData.gitMeta;
+  const branch = deployData.branch;
+
+  // Handle preview branch logic
+  if (deployData.environment === "preview" && branch) {
+    if (gitMeta?.pullRequestState === "merged" || gitMeta?.pullRequestState === "closed") {
+      log.message(`Pull request ${gitMeta?.pullRequestNumber} is ${gitMeta?.pullRequestState}.`);
+      const $buildSpinner = spinner();
+      $buildSpinner.start(`Archiving preview branch: "${branch}"`);
+      const result = await archivePreviewBranch(authorization, branch, resolvedConfig.project);
+      $buildSpinner.stop(
+        result ? `Successfully archived "${branch}"` : `Failed to archive "${branch}".`
+      );
+      return;
+    }
+
+    logger.debug("Upserting branch", { env: deployData.environment, branch });
+    const branchEnv = await upsertBranch({
+      accessToken: authorization.auth.accessToken,
+      apiUrl: authorization.auth.apiUrl,
+      projectRef: resolvedConfig.project,
+      branch,
+      gitMeta,
+    });
+
+    logger.debug("Upserted branch env", branchEnv);
+
+    log.success(`Using preview branch "${branch}"`);
+
+    if (!branchEnv) {
+      throw new Error(`Failed to create branch "${branch}"`);
+    }
+  }
+
+  const projectClient = await getProjectClient({
+    accessToken: authorization.auth.accessToken,
+    apiUrl: authorization.auth.apiUrl,
+    projectRef: resolvedConfig.project,
+    env: deployData.environment,
+    branch,
+    profile: options.profile,
+  });
+
+  if (!projectClient) {
+    throw new Error("Failed to get project client");
+  }
+
+  const deploymentResponse = await projectClient.client.initializeDeployment({
+    contentHash: deployData.contentHash,
+    userId: authorization.userId,
+    gitMeta,
+    type: deployData.buildManifest.features?.run_engine_v2 ? "MANAGED" : "V1",
+    runtime: deployData.runtime,
+    isNativeBuild: false,
+  });
+
+  if (!deploymentResponse.success) {
+    throw new Error(`Failed to start deployment: ${deploymentResponse.error}`);
+  }
+
+  const deployment = deploymentResponse.data;
+  const version = deployment.version;
+
+  // TODO: Implement automatic image retagging
+  // Example ECR implementation:
+  // const sourceTag = deployData.imageTag; // e.g., localhost:5001/trigger/proj_abc:0f7d1460
+  // const targetTag = deployment.imageTag; // e.g., localhost:5001/trigger/proj_abc:20250725.10.prod
+  //
+  // // For ECR:
+  // const manifest = await x("aws", ["ecr", "batch-get-image",
+  //   "--repository-name", "trigger/proj_abc",
+  //   "--image-ids", "imageTag=0f7d1460",
+  //   "--output", "text",
+  //   "--query", "images[].imageManifest"
+  // ]);
+  // await x("aws", ["ecr", "put-image",
+  //   "--repository-name", "trigger/proj_abc",
+  //   "--image-tag", "20250725.10.prod",
+  //   "--image-manifest", manifest.stdout
+  // ]);
+
+  // Log retagging command for manual execution
+  if (deployData.imageTag && deployment.imageTag && deployData.imageTag !== deployment.imageTag) {
+    const sourceTag = deployData.imageTag.split(':').pop();
+    const targetTag = deployment.imageTag.split(':').pop();
+    const [registry, repoPath] = deployData.imageTag.split('/').slice(0, -1).join('/').split('/');
+    const repository = deployData.imageTag.split(':')[0].split('/').slice(-2).join('/');
+
+    logger.info(`\nImage needs retagging from ${sourceTag} to ${targetTag}`);
+    logger.info(`Run this command to retag:\n`);
+
+    if (deployData.imageTag.includes('.ecr.') && deployData.imageTag.includes('.amazonaws.com')) {
+      // ECR retagging command
+      logger.info(`MANIFEST=$(aws ecr batch-get-image --repository-name ${repository} --image-ids imageTag=${sourceTag} --output text --query 'images[].imageManifest')`);
+      logger.info(`aws ecr put-image --repository-name ${repository} --image-tag ${targetTag} --image-manifest "$MANIFEST"\n`);
+    } else {
+      // Local/Docker registry retagging
+      logger.info(`docker tag ${deployData.imageTag} ${deployment.imageTag}`);
+      logger.info(`docker push ${deployment.imageTag}\n`);
+    }
+
+    // Wait 5 seconds to give user time to see the command
+    await new Promise(resolve => setTimeout(resolve, 5000));
+  }
+
+  const rawDeploymentLink = `${authorization.dashboardUrl}/projects/v3/${resolvedConfig.project}/deployments/${deployment.shortCode}`;
+  const rawTestLink = `${authorization.dashboardUrl}/projects/v3/${
+    resolvedConfig.project
+  }/test?environment=${deployData.environment === "prod" ? "prod" : "stg"}`;
+
+  const deploymentLink = cliLink("View deployment", rawDeploymentLink);
+  const testLink = cliLink("Test tasks", rawTestLink);
+
+  const $spinner = spinner();
+
+  // Handle environment variable syncing
+  const hasVarsToSync =
+    Object.keys(deployData.buildManifest.deploy?.sync?.env || {}).length > 0 ||
+    (branch && Object.keys(deployData.buildManifest.deploy?.sync?.parentEnv || {}).length > 0);
+
+  if (hasVarsToSync) {
+    const childVars = deployData.buildManifest.deploy?.sync?.env ?? {};
+    const parentVars = deployData.buildManifest.deploy?.sync?.parentEnv ?? {};
+
+    const numberOfEnvVars = Object.keys(childVars).length + Object.keys(parentVars).length;
+    const vars = numberOfEnvVars === 1 ? "var" : "vars";
+
+    if (!options.skipSyncEnvVars) {
+      $spinner.start(`Syncing ${numberOfEnvVars} env ${vars} with the server`);
+
+      const uploadResult = await syncEnvVarsWithServer(
+        projectClient.client,
+        resolvedConfig.project,
+        deployData.environment,
+        childVars,
+        parentVars
+      );
+
+      if (!uploadResult.success) {
+        await failDeploy(
+          projectClient.client,
+          deployment,
+          {
+            name: "SyncEnvVarsError",
+            message: `Failed to sync ${numberOfEnvVars} env ${vars} with the server: ${uploadResult.error}`,
+          },
+          "",
+          $spinner
+        );
+        throw new SkipLoggingError("Failed to sync environment variables");
+      } else {
+        $spinner.stop(`Successfully synced ${numberOfEnvVars} env ${vars} with the server`);
+      }
+    } else {
+      logger.log(
+        "Skipping syncing env vars. The environment variables in your project have changed, but the --skip-sync-env-vars flag was provided."
+      );
+    }
+  }
+
+  // Create background worker if we have index metadata
+  if (deployData.indexMetadata) {
+    const backgroundWorkerBody: CreateBackgroundWorkerRequestBody = {
+      localOnly: true,
+      metadata: {
+        contentHash: deployData.indexMetadata.contentHash,
+        packageVersion: deployData.indexMetadata.packageVersion,
+        cliPackageVersion: deployData.indexMetadata.cliPackageVersion,
+        tasks: deployData.indexMetadata.tasks,
+        queues: deployData.indexMetadata.queues,
+        sourceFiles: deployData.indexMetadata.sourceFiles,
+        runtime: deployData.indexMetadata.runtime,
+        runtimeVersion: deployData.indexMetadata.runtimeVersion,
+      },
+      engine: "V2",
+      supportsLazyAttempts: true,
+      buildPlatform: deployData.indexMetadata.buildPlatform,
+      targetPlatform: deployData.indexMetadata.targetPlatform,
+    };
+
+    const createResponse = await projectClient.client.createDeploymentBackgroundWorker(
+      deployment.id,
+      backgroundWorkerBody
+    );
+
+    if (!createResponse.success) {
+      logger.error(
+        JSON.stringify({
+          message: "Failed to create background worker",
+          error: createResponse.error,
+        })
+      );
+    } else {
+      logger.debug(
+        JSON.stringify({
+          message: "Background worker created",
+          createResponse: createResponse.data,
+        })
+      );
+    }
+  }
+
+  if (isCI) {
+    log.step(`Deploying version ${version}\n`);
+  } else {
+    if (isLinksSupported) {
+      $spinner.start(`Deploying version ${version} ${deploymentLink}`);
+    } else {
+      $spinner.start(`Deploying version ${version}`);
+    }
+  }
+
+  const finalizeResponse = await projectClient.client.finalizeDeployment(
+    deployment.id,
+    {
+      ...(options.skipDigest ? {} : { imageDigest: deployData.imageDigest }),
+      skipPromotion: options.skipPromotion,
+    },
+    (logMessage) => {
+      if (isCI) {
+        console.log(logMessage);
+        return;
+      }
+
+      if (isLinksSupported) {
+        $spinner.message(`Deploying version ${version} ${deploymentLink}: ${logMessage}`);
+      } else {
+        $spinner.message(`Deploying version ${version}: ${logMessage}`);
+      }
+    }
+  );
+
+  if (!finalizeResponse.success) {
+    await failDeploy(
+      projectClient.client,
+      deployment,
+      { name: "FinalizeError", message: finalizeResponse.error },
+      "",
+      $spinner
+    );
+
+    throw new SkipLoggingError("Failed to finalize deployment");
+  }
+
+  if (isCI) {
+    log.step(`Successfully deployed version ${version}`);
+  } else {
+    $spinner.stop(`Successfully deployed version ${version}`);
+  }
+
+  const taskCount = deployData.taskCount || 0;
+
+  outro(
+    `Version ${version} deployed with ${taskCount} detected task${taskCount === 1 ? "" : "s"} ${
+      isLinksSupported ? `| ${deploymentLink} | ${testLink}` : ""
+    }`
+  );
+
+  if (!isLinksSupported) {
+    console.log("View deployment");
+    console.log(rawDeploymentLink);
+    console.log(); // new line
+    console.log("Test tasks");
+    console.log(rawTestLink);
+  }
+
+  setGithubActionsOutputAndEnvVars({
+    envVars: {
+      TRIGGER_DEPLOYMENT_VERSION: version,
+      TRIGGER_VERSION: version,
+      TRIGGER_DEPLOYMENT_SHORT_CODE: deployment.shortCode,
+      TRIGGER_DEPLOYMENT_URL: `${authorization.dashboardUrl}/projects/v3/${resolvedConfig.project}/deployments/${deployment.shortCode}`,
+      TRIGGER_TEST_URL: `${authorization.dashboardUrl}/projects/v3/${
+        resolvedConfig.project
+      }/test?environment=${deployData.environment === "prod" ? "prod" : "stg"}`,
+    },
+    outputs: {
+      deploymentVersion: version,
+      workerVersion: version,
+      deploymentShortCode: deployment.shortCode,
+      deploymentUrl: `${authorization.dashboardUrl}/projects/v3/${resolvedConfig.project}/deployments/${deployment.shortCode}`,
+      testUrl: `${authorization.dashboardUrl}/projects/v3/${
+        resolvedConfig.project
+      }/test?environment=${deployData.environment === "prod" ? "prod" : "stg"}`,
+      needsPromotion: options.skipPromotion ? "true" : "false",
+    },
+  });
 }
 
 export function verifyDirectory(dir: string, projectPath: string) {

--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -3,15 +3,17 @@ import { depot } from "@depot/cli";
 import { x } from "tinyexec";
 import { BuildManifest, BuildRuntime } from "@trigger.dev/core/v3/schemas";
 import { networkInterfaces } from "os";
-import { join } from "path";
+import { join, resolve } from "path";
 import { safeReadJSONFile } from "../utilities/fileSystem.js";
-import { readFileSync } from "fs";
+import { cpSync, mkdirSync, readFileSync, statSync } from "fs";
 
 import { isLinux } from "std-env";
 import { z } from "zod";
 import { assertExhaustive } from "../utilities/assertExhaustive.js";
 import { tryCatch } from "@trigger.dev/core";
 import { CliApiClient } from "../apiClient.js";
+import { pathToFileURL } from "url";
+import type { ContainerfileTemplate } from "./containerfile-template.js";
 
 export interface BuildImageOptions {
   // Common options
@@ -46,13 +48,12 @@ export interface BuildImageOptions {
   extraCACerts?: string;
   apiUrl: string;
   apiKey: string;
-  apiClient: CliApiClient;
+  apiClient?: CliApiClient;
   branchName?: string;
   buildEnvVars?: Record<string, string | undefined>;
+  indexEnvVars?: Record<string, string>; // Environment variables for indexing
   onLog?: (log: string) => void;
-
-  // Optional deployment spinner
-  deploymentSpinner?: any; // Replace 'any' with the actual type if known
+  baseImageNode?: string; // Custom base image for Node.js runtime
 }
 
 export async function buildImage(options: BuildImageOptions): Promise<BuildImageResults> {
@@ -81,6 +82,7 @@ export async function buildImage(options: BuildImageOptions): Promise<BuildImage
     apiClient,
     branchName,
     buildEnvVars,
+    indexEnvVars,
     network,
     builder,
     compression,
@@ -88,6 +90,7 @@ export async function buildImage(options: BuildImageOptions): Promise<BuildImage
     compressionLevel,
     forceCompression,
     onLog,
+    baseImageNode,
   } = options;
 
   if (isLocalBuild) {
@@ -111,6 +114,7 @@ export async function buildImage(options: BuildImageOptions): Promise<BuildImage
       apiClient,
       branchName,
       buildEnvVars,
+      indexEnvVars,
       network,
       builder,
       compression,
@@ -118,6 +122,7 @@ export async function buildImage(options: BuildImageOptions): Promise<BuildImage
       compressionLevel,
       forceCompression,
       onLog,
+      baseImageNode,
     });
   }
 
@@ -149,7 +154,9 @@ export async function buildImage(options: BuildImageOptions): Promise<BuildImage
     compression,
     compressionLevel,
     forceCompression,
+    indexEnvVars,
     onLog,
+    baseImageNode,
   });
 }
 
@@ -175,7 +182,9 @@ export interface DepotBuildImageOptions {
   compression?: "zstd" | "gzip";
   compressionLevel?: number;
   forceCompression?: boolean;
+  indexEnvVars?: Record<string, string>;
   onLog?: (log: string) => void;
+  baseImageNode?: string;
 }
 
 type BuildImageSuccess = {
@@ -234,6 +243,8 @@ async function remoteBuildImage(options: DepotBuildImageOptions): Promise<BuildI
     `TRIGGER_PREVIEW_BRANCH=${options.branchName ?? ""}`,
     "--build-arg",
     `TRIGGER_SECRET_KEY=${options.apiKey}`,
+    "--build-arg",
+    `TRIGGER_ENV_VARS=${JSON.stringify(options.indexEnvVars || {})}`,
     ...(buildArgs || []),
     ...(options.extraCACerts ? ["--build-arg", `NODE_EXTRA_CA_CERTS=${options.extraCACerts}`] : []),
     "--progress",
@@ -335,12 +346,13 @@ interface SelfHostedBuildImageOptions {
   authenticateToRegistry?: boolean;
   apiUrl: string;
   apiKey: string;
-  apiClient: CliApiClient;
+  apiClient?: CliApiClient;
   branchName?: string;
   noCache?: boolean;
   useRegistryCache?: boolean;
   extraCACerts?: string;
   buildEnvVars?: Record<string, string | undefined>;
+  indexEnvVars?: Record<string, string>;
   network?: string;
   builder: string;
   load?: boolean;
@@ -349,6 +361,7 @@ interface SelfHostedBuildImageOptions {
   compressionLevel?: number;
   forceCompression?: boolean;
   onLog?: (log: string) => void;
+  baseImageNode?: string;
 }
 
 async function localBuildImage(options: SelfHostedBuildImageOptions): Promise<BuildImageResults> {
@@ -486,6 +499,14 @@ async function localBuildImage(options: SelfHostedBuildImageOptions): Promise<Bu
       };
     }
 
+    if (!apiClient) {
+      return {
+        ok: false as const,
+        error: "API client is required for registry authentication",
+        logs: "",
+      };
+    }
+
     const [credentialsError, credentials] = await tryCatch(
       getDockerUsernameAndPassword(apiClient, deploymentId)
     );
@@ -564,6 +585,7 @@ async function localBuildImage(options: SelfHostedBuildImageOptions): Promise<Bu
     options.imagePlatform,
     options.network ? `--network=${options.network}` : undefined,
     addHost ? `--add-host=${addHost}` : undefined,
+    load ? "--load" : undefined,
     "--provenance",
     "false",
     "--metadata-file",
@@ -584,14 +606,18 @@ async function localBuildImage(options: SelfHostedBuildImageOptions): Promise<Bu
     `TRIGGER_PREVIEW_BRANCH=${options.branchName ?? ""}`,
     "--build-arg",
     `TRIGGER_SECRET_KEY=${options.apiKey}`,
+    "--build-arg",
+    `TRIGGER_ENV_VARS=${JSON.stringify(options.indexEnvVars || {})}`,
     ...(buildArgs || []),
     ...(options.extraCACerts ? ["--build-arg", `NODE_EXTRA_CA_CERTS=${options.extraCACerts}`] : []),
     "--progress",
     "plain",
+    "-t",
+    options.imageTag,
     ".", // The build context
   ].filter(Boolean) as string[];
 
-  logger.debug(`docker ${args.join(" ")}`, { cwd: options.cwd });
+  logger.info(`docker ${args.join(" ")}`, { cwd: options.cwd });
 
   const buildProcess = x("docker", args, {
     nodeOptions: {
@@ -619,12 +645,181 @@ async function localBuildImage(options: SelfHostedBuildImageOptions): Promise<Bu
     };
   }
 
+  // Always extract files using docker cp
+  // Create the docker-export directory
+  const dockerExportDir = join(options.cwd, "docker-export");
+  logger.debug("Creating docker-export directory", { path: dockerExportDir });
+  mkdirSync(dockerExportDir, { recursive: true });
+
+  // Create a temporary container to extract files
+  const containerName = `trigger-extract-${Date.now()}`;
+  
+  logger.debug("Creating container for file extraction", { 
+    containerName, 
+    imageTag: options.imageTag,
+    cwd: options.cwd 
+  });
+  
+  const createProcess = x("docker", ["create", "--name", containerName, options.imageTag], {
+    nodeOptions: { cwd: options.cwd },
+  });
+  
+  for await (const line of createProcess) {
+    errors.push(line);
+    logger.debug(line);
+  }
+  
+  if (createProcess.exitCode !== 0) {
+    logger.error("Failed to create extraction container", { 
+      exitCode: createProcess.exitCode,
+      containerName,
+      imageTag: options.imageTag 
+    });
+    return {
+      ok: false as const,
+      error: "Error creating container for file extraction",
+      logs: extractLogs(errors),
+    };
+  }
+  
+  logger.debug("Container created successfully", { containerName });
+
+  // Extract the files we need
+  const filesToExtract = [
+    { source: "/app/index.json", dest: "index.json", required: true },
+    { source: "/app/index-metadata.json", dest: "index-metadata.json", required: true },
+    { source: "/app/index-error.json", dest: "index-error.json", required: false },
+  ];
+  
+  logger.debug("Starting file extraction", { 
+    filesToExtract,
+    targetDir: dockerExportDir 
+  });
+  
+  for (const { source, dest, required } of filesToExtract) {
+    logger.debug("Extracting file from container", { 
+      source, 
+      dest, 
+      required,
+      containerName,
+      targetPath: join(dockerExportDir, dest)
+    });
+    
+    const cpCommand = ["cp", `${containerName}:${source}`, "./docker-export/"];
+    logger.debug("Running docker cp command", { command: `docker ${cpCommand.join(" ")}` });
+    
+    const cpProcess = x("docker", cpCommand, {
+      nodeOptions: { cwd: options.cwd },
+    });
+    
+    const cpErrors: string[] = [];
+    for await (const line of cpProcess) {
+      cpErrors.push(line);
+      logger.debug(`docker cp output: ${line}`);
+    }
+    
+    logger.debug("Docker cp process completed", { 
+      exitCode: cpProcess.exitCode,
+      source,
+      errorCount: cpErrors.length
+    });
+    
+    if (cpProcess.exitCode !== 0) {
+      logger.error("Failed to extract file", { 
+        source, 
+        required, 
+        exitCode: cpProcess.exitCode,
+        errors: cpErrors 
+      });
+      
+      if (required) {
+        logger.error("Critical file extraction failed, cleaning up container");
+        // Clean up the container before failing
+        await x("docker", ["rm", containerName], { nodeOptions: { cwd: options.cwd } });
+        
+        return {
+          ok: false as const,
+          error: `Failed to extract critical file ${source} from container: ${cpErrors.join("\n")}`,
+          logs: extractLogs(errors),
+        };
+      } else {
+        logger.warn(`Failed to extract optional file ${source}, continuing...`);
+      }
+    } else {
+      logger.debug("File extraction successful", { source, dest });
+    }
+    
+    // Verify the file was actually copied
+    if (required) {
+      const extractedPath = join(options.cwd, "docker-export", dest);
+      logger.debug("Verifying extracted file", { path: extractedPath });
+      
+      try {
+        const stats = statSync(extractedPath);
+        if (!stats.isFile()) {
+          logger.error("Extracted path is not a file", { 
+            path: extractedPath, 
+            isDirectory: stats.isDirectory(),
+            mode: stats.mode 
+          });
+          
+          // Clean up the container before failing
+          logger.debug("Cleaning up container before failing");
+          await x("docker", ["rm", containerName], { nodeOptions: { cwd: options.cwd } });
+          
+          return {
+            ok: false as const,
+            error: `Extracted file ${dest} is not a valid file at ${extractedPath}`,
+            logs: extractLogs(errors),
+          };
+        }
+        logger.debug(`Successfully verified extracted file`, { 
+          source,
+          dest,
+          path: extractedPath,
+          sizeBytes: stats.size,
+          modified: stats.mtime
+        });
+      } catch (e) {
+        logger.error("Failed to verify extracted file", { 
+          path: extractedPath,
+          error: e instanceof Error ? e.message : String(e),
+          errorType: e?.constructor?.name
+        });
+        
+        // Clean up the container before failing
+        logger.debug("Cleaning up container before failing");
+        await x("docker", ["rm", containerName], { nodeOptions: { cwd: options.cwd } });
+        
+        return {
+          ok: false as const,
+          error: `Failed to verify extracted file ${dest}: ${e instanceof Error ? e.message : String(e)}`,
+          logs: extractLogs(errors),
+        };
+      }
+    }
+  }
+
+  logger.debug("All files extracted successfully, cleaning up container", { containerName });
+
+  // Clean up the container
+  const rmProcess = x("docker", ["rm", containerName], {
+    nodeOptions: { cwd: options.cwd },
+  });
+  
+  for await (const line of rmProcess) {
+    logger.debug(`docker rm output: ${line}`);
+  }
+  
+  logger.debug("Container cleanup completed", { exitCode: rmProcess.exitCode });
+
+  // Get the digest from the build metadata first
   const metadataPath = join(options.cwd, "metadata.json");
   const rawMetadata = await safeReadJSONFile(metadataPath);
 
   const meta = BuildKitMetadata.safeParse(rawMetadata);
 
-  let digest: string | undefined;
+  let buildDigest: string | undefined;
   if (!meta.success) {
     logger.error("Failed to parse metadata.json", {
       errors: meta.error.message,
@@ -632,10 +827,104 @@ async function localBuildImage(options: SelfHostedBuildImageOptions): Promise<Bu
     });
   } else {
     logger.debug("Parsed metadata.json", { metadata: meta.data, path: metadataPath });
-
-    // Always use the manifest (list) digest
-    digest = meta.data["containerimage.digest"];
+    buildDigest = meta.data["containerimage.digest"];
+    logger.info("Build digest from metadata.json", { buildDigest });
   }
+
+  logger.debug("PUSH", push);
+
+  let finalDigest: string | undefined = buildDigest;
+
+  // If push is true, push the image
+  if (push) {
+    logger.debug("PUSHING IMAGE TO REGISTRY");
+    options.onLog?.("Pushing image to registry...");
+    
+    const pushProcess = x("docker", ["push", options.imageTag], {
+      nodeOptions: { cwd: options.cwd },
+    });
+    
+    for await (const line of pushProcess) {
+      errors.push(line);
+      logger.debug(line);
+      options.onLog?.(line);
+    }
+    
+    if (pushProcess.exitCode !== 0) {
+      return {
+        ok: false as const,
+        error: "Error pushing image to registry",
+        logs: extractLogs(errors),
+      };
+    }
+    
+    options.onLog?.("Image pushed successfully");
+    logger.debug("IMAGE PUSHED SUCCESSFULLY");
+
+    // Get the digest of the pushed image
+    const inspectProcess = x("docker", ["inspect", "--format={{index .RepoDigests 0}}", options.imageTag], {
+      nodeOptions: { cwd: options.cwd },
+    });
+    
+    let pushedDigest: string | undefined;
+    for await (const line of inspectProcess) {
+      if (line.trim()) {
+        // Extract just the digest part (after the @)
+        const parts = line.trim().split('@');
+        if (parts.length === 2) {
+          pushedDigest = parts[1];
+        }
+        break;
+      }
+    }
+    
+    if (pushedDigest) {
+      logger.info("Push digest from docker inspect", { pushedDigest });
+      finalDigest = pushedDigest;
+      
+      // IMPORTANT NOTE: We must use the pushed digest for the final digest or else shas don't match and this fails
+
+      // Compare digests
+      // if (buildDigest && buildDigest !== pushedDigest) {
+      //   logger.error("Digest mismatch detected!", {
+      //     buildDigest,
+      //     pushedDigest,
+      //     imageTag: options.imageTag,
+      //     imagePlatform: options.imagePlatform
+      //   });
+        
+      //   // For multi-platform builds, this is expected behavior
+      //   if (options.imagePlatform.includes(",")) {
+      //     logger.warn("Multi-platform build detected. Using pushed manifest list digest instead of build digest.");
+      //   } else {
+      //     throw new Error(`Digest mismatch: build digest (${buildDigest}) != push digest (${pushedDigest})`);
+      //   }
+      // }
+    } else {
+      logger.warn("Could not retrieve push digest from docker inspect");
+    }
+  }
+
+  // Copy the docker-export folder to the test directory
+  // const testDir = "/Users/conneraldrich/Development/Projects/govsignals/trigger.dev/references/v3-catalog/test";
+  // const dockerExportPath = join(options.cwd, "docker-export");
+  
+  // try {
+  //   // Ensure the test directory exists
+  //   mkdirSync(testDir, { recursive: true });
+
+  //   // Copy the docker-export folder to the test directory
+  //   cpSync(dockerExportPath, testDir, { recursive: true });
+    
+  //   logger.info(`Copied docker-export from ${dockerExportPath} to ${testDir}`);
+  //   options.onLog?.(`Copied docker-export to ${testDir}`);
+  // } catch (e) {
+  //   logger.error("Failed to copy docker-export to test directory", {
+  //     error: e instanceof Error ? e.message : JSON.stringify(e),
+  //     source: dockerExportPath,
+  //     destination: testDir,
+  //     });
+  //   }
 
   // Get the image size
   const sizeProcess = x("docker", ["image", "inspect", options.imageTag, "--format={{.Size}}"], {
@@ -665,7 +954,7 @@ async function localBuildImage(options: SelfHostedBuildImageOptions): Promise<Bu
   return {
     ok: true as const,
     imageSizeBytes,
-    digest,
+    digest: finalDigest,
     logs: extractLogs(errors),
   };
 }
@@ -683,6 +972,8 @@ export type GenerateContainerfileOptions = {
   image: BuildManifest["image"];
   indexScript: string;
   entrypoint: string;
+  baseImageNode?: string;
+  containerfileModule?: string;
 };
 
 const BASE_IMAGE: Record<BuildRuntime, string> = {
@@ -694,19 +985,7 @@ const BASE_IMAGE: Record<BuildRuntime, string> = {
 
 const DEFAULT_PACKAGES = ["busybox", "ca-certificates", "dumb-init", "git", "openssl"];
 
-export async function generateContainerfile(options: GenerateContainerfileOptions) {
-  switch (options.runtime) {
-    case "node":
-    case "node-22": {
-      return await generateNodeContainerfile(options);
-    }
-    case "bun": {
-      return await generateBunContainerfile(options);
-    }
-  }
-}
-
-const parseGenerateOptions = (options: GenerateContainerfileOptions) => {
+export const parseGenerateOptions = (options: GenerateContainerfileOptions) => {
   const buildArgs = Object.entries(options.build.env || {})
     .flatMap(([key]) => `ARG ${key}`)
     .join("\n");
@@ -721,9 +1000,15 @@ const parseGenerateOptions = (options: GenerateContainerfileOptions) => {
   const packages = Array.from(new Set(DEFAULT_PACKAGES.concat(options.image?.pkgs || []))).join(
     " "
   );
+  
+  // Use custom base image for Node.js runtimes if provided
+  let baseImage = BASE_IMAGE[options.runtime];
+  if (options.baseImageNode && (options.runtime === "node" || options.runtime === "node-22")) {
+    baseImage = options.baseImageNode;
+  }
 
   return {
-    baseImage: BASE_IMAGE[options.runtime],
+    baseImage,
     baseInstructions,
     buildArgs,
     buildEnvVars,
@@ -732,7 +1017,56 @@ const parseGenerateOptions = (options: GenerateContainerfileOptions) => {
   };
 };
 
-async function generateBunContainerfile(options: GenerateContainerfileOptions) {
+async function loadContainerfileModule(modulePath: string): Promise<ContainerfileTemplate> {
+  const absolutePath = resolve(modulePath);
+  
+  try {
+    // Convert to file URL for proper ESM import
+    const moduleUrl = pathToFileURL(absolutePath).href;
+    
+    // Dynamic import of the module
+    const module = await import(moduleUrl);
+    
+    // Return the default export
+    if (!module.default) {
+      throw new Error(`Module ${modulePath} does not have a default export`);
+    }
+    
+    return module.default;
+  } catch (error) {
+    logger.error(`Failed to load containerfile module from ${modulePath}`, error);
+    throw new Error(`Failed to load containerfile module: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export async function generateContainerfile(options: GenerateContainerfileOptions) {
+  // If a custom module is specified, use it
+  if (options.containerfileModule) {
+    try {
+      const template = await loadContainerfileModule(options.containerfileModule);
+      
+      // Pass the full options directly to the template for complete control
+      const containerfile = await template.generate(options);
+      return containerfile;
+    } catch (error) {
+      logger.error("Failed to generate containerfile from module", error);
+      throw error;
+    }
+  }
+  
+  // Fall back to built-in templates
+  switch (options.runtime) {
+    case "node":
+    case "node-22": {
+      return await generateNodeContainerfile(options);
+    }
+    case "bun": {
+      return await generateBunContainerfile(options);
+    }
+  }
+}
+
+export async function generateBunContainerfile(options: GenerateContainerfileOptions) {
   const { baseImage, buildArgs, buildEnvVars, postInstallCommands, baseInstructions, packages } =
     parseGenerateOptions(options);
 
@@ -786,6 +1120,7 @@ ARG NODE_EXTRA_CA_CERTS
 ARG TRIGGER_SECRET_KEY
 ARG TRIGGER_API_URL
 ARG TRIGGER_PREVIEW_BRANCH
+ARG TRIGGER_ENV_VARS
 
 ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \
     TRIGGER_DEPLOYMENT_ID=\${TRIGGER_DEPLOYMENT_ID} \
@@ -796,6 +1131,7 @@ ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \
     TRIGGER_API_URL=\${TRIGGER_API_URL} \
     TRIGGER_PREVIEW_BRANCH=\${TRIGGER_PREVIEW_BRANCH} \
     NODE_EXTRA_CA_CERTS=\${NODE_EXTRA_CA_CERTS} \
+    TRIGGER_ENV_VARS=\${TRIGGER_ENV_VARS} \
     NODE_ENV=production
 
 ARG TARGETPLATFORM
@@ -834,7 +1170,7 @@ CMD []
   `;
 }
 
-async function generateNodeContainerfile(options: GenerateContainerfileOptions) {
+export async function generateNodeContainerfile(options: GenerateContainerfileOptions) {
   const { baseImage, buildArgs, buildEnvVars, postInstallCommands, baseInstructions, packages } =
     parseGenerateOptions(options);
 
@@ -894,6 +1230,7 @@ ARG NODE_EXTRA_CA_CERTS
 ARG TRIGGER_SECRET_KEY
 ARG TRIGGER_API_URL
 ARG TRIGGER_PREVIEW_BRANCH
+ARG TRIGGER_ENV_VARS
 
 ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \
     TRIGGER_DEPLOYMENT_ID=\${TRIGGER_DEPLOYMENT_ID} \
@@ -905,6 +1242,7 @@ ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \
     TRIGGER_PREVIEW_BRANCH=\${TRIGGER_PREVIEW_BRANCH} \
     TRIGGER_LOG_LEVEL=debug \
     NODE_EXTRA_CA_CERTS=\${NODE_EXTRA_CA_CERTS} \
+    TRIGGER_ENV_VARS=\${TRIGGER_ENV_VARS} \
     NODE_ENV=production \
     NODE_OPTIONS="--max_old_space_size=8192"
 
@@ -936,8 +1274,11 @@ ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \
 # Copy the files from the install stage
 COPY --from=build --chown=node:node /app ./
 
-# Copy the index.json file from the indexer stage
+# Copy the index.json file from the indexer stage if it exists
 COPY --from=indexer --chown=node:node /app/index.json ./
+COPY --from=indexer --chown=node:node /app/index-metadata.json ./
+# index-error.json is optional - it only exists if indexing failed
+COPY --from=indexer --chown=node:node /app/index-error.json* ./
 
 ENTRYPOINT [ "dumb-init", "node", "${options.entrypoint}" ]
 CMD []
@@ -1100,20 +1441,21 @@ function shouldPush(imageTag: string, push?: boolean) {
 
 // Don't load if we're pushing, unless the user explicitly wants to load
 function shouldLoad(load?: boolean, push?: boolean) {
-  switch (load) {
-    case true: {
-      return true;
-    }
-    case false: {
-      return false;
-    }
-    case undefined: {
-      return push ? false : true;
-    }
-    default: {
-      assertExhaustive(load);
-    }
-  }
+  return true; // We have to load the image for file extraction
+  // switch (load) {
+  //   case true: {
+  //     return true;
+  //   }
+  //   case false: {
+  //     return false;
+  //   }
+  //   case undefined: {
+  //     return push ? false : true;
+  //   }
+  //   default: {
+  //     assertExhaustive(load);
+  //   }
+  // }
 }
 
 function getOutputOptions({

--- a/packages/cli-v3/src/deploy/containerfile-template.ts
+++ b/packages/cli-v3/src/deploy/containerfile-template.ts
@@ -1,0 +1,29 @@
+import type { GenerateContainerfileOptions } from "./buildImage.js";
+
+export interface ContainerfileTemplate {
+  generate(options: GenerateContainerfileOptions): Promise<string> | string;
+}
+
+// Helper function to format build args
+export function formatBuildArgs(env: Record<string, string | undefined> | undefined): string {
+  if (!env) return "";
+  return Object.entries(env)
+    .filter(([_, value]) => value !== undefined)
+    .map(([key]) => `ARG ${key}`)
+    .join("\n");
+}
+
+// Helper function to format env vars
+export function formatEnvVars(env: Record<string, string | undefined> | undefined): string {
+  if (!env) return "";
+  return Object.entries(env)
+    .filter(([_, value]) => value !== undefined)
+    .map(([key]) => `ENV ${key}=$${key}`)
+    .join("\n");
+}
+
+// Helper function to format RUN commands
+export function formatRunCommands(commands: string[] | undefined): string {
+  if (!commands || commands.length === 0) return "";
+  return commands.map(cmd => `RUN ${cmd}`).join("\n");
+} 

--- a/packages/cli-v3/src/entryPoints/managed-index-controller.ts
+++ b/packages/cli-v3/src/entryPoints/managed-index-controller.ts
@@ -1,12 +1,10 @@
 import {
   BuildManifest,
-  CreateBackgroundWorkerRequestBody,
   serializeIndexingError,
 } from "@trigger.dev/core/v3";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { env } from "std-env";
-import { CliApiClient } from "../apiClient.js";
 import { indexWorkerManifest } from "../indexing/indexWorkerManifest.js";
 import { resolveSourceFiles } from "../utilities/sourceFiles.js";
 import { execOptionsForRuntime } from "@trigger.dev/core/v3/build";
@@ -27,12 +25,6 @@ async function bootstrap() {
     process.exit(1);
   }
 
-  const cliApiClient = new CliApiClient(
-    env.TRIGGER_API_URL,
-    env.TRIGGER_SECRET_KEY,
-    env.TRIGGER_PREVIEW_BRANCH
-  );
-
   if (!env.TRIGGER_PROJECT_REF) {
     console.error("TRIGGER_PROJECT_REF is not set");
     process.exit(1);
@@ -45,7 +37,6 @@ async function bootstrap() {
 
   return {
     buildManifest,
-    cliApiClient,
     projectRef: env.TRIGGER_PROJECT_REF,
     deploymentId: env.TRIGGER_DEPLOYMENT_ID,
   };
@@ -54,7 +45,6 @@ async function bootstrap() {
 type BootstrapResult = Awaited<ReturnType<typeof bootstrap>>;
 
 async function indexDeployment({
-  cliApiClient,
   projectRef,
   deploymentId,
   buildManifest,
@@ -63,10 +53,14 @@ async function indexDeployment({
   const stderr: string[] = [];
 
   try {
-    const $env = await cliApiClient.getEnvironmentVariables(projectRef);
-
-    if (!$env.success) {
-      throw new Error(`Failed to fetch environment variables: ${$env.error}`);
+    // Parse environment variables from TRIGGER_ENV_VARS build arg
+    const envVarsJson = env.TRIGGER_ENV_VARS || "{}";
+    let envVars: Record<string, string> = {};
+    
+    try {
+      envVars = JSON.parse(envVarsJson);
+    } catch (e) {
+      console.error("Failed to parse TRIGGER_ENV_VARS:", e);
     }
 
     const workerManifest = await indexWorkerManifest({
@@ -74,7 +68,7 @@ async function indexDeployment({
       indexWorkerPath: buildManifest.indexWorkerEntryPoint,
       buildManifestPath: "./build.json",
       nodeOptions: execOptionsForRuntime(buildManifest.runtime, buildManifest),
-      env: $env.data.variables,
+      env: envVars,
       otelHookExclude: buildManifest.otelImportHook?.exclude,
       otelHookInclude: buildManifest.otelImportHook?.include,
       handleStdout(data) {
@@ -97,48 +91,30 @@ async function indexDeployment({
     const buildPlatform = process.env.BUILDPLATFORM;
     const targetPlatform = process.env.TARGETPLATFORM;
 
-    const backgroundWorkerBody: CreateBackgroundWorkerRequestBody = {
-      localOnly: true,
-      metadata: {
-        contentHash: buildManifest.contentHash,
-        packageVersion: buildManifest.packageVersion,
-        cliPackageVersion: buildManifest.cliPackageVersion,
-        tasks: workerManifest.tasks,
-        queues: workerManifest.queues,
-        sourceFiles,
-        runtime: workerManifest.runtime,
-        runtimeVersion: workerManifest.runtimeVersion,
-      },
-      engine: "V2",
-      supportsLazyAttempts: true,
+    // Write metadata that will be needed for the background worker creation
+    const indexMetadata = {
+      contentHash: buildManifest.contentHash,
+      packageVersion: buildManifest.packageVersion,
+      cliPackageVersion: buildManifest.cliPackageVersion,
+      tasks: workerManifest.tasks,
+      queues: workerManifest.queues,
+      sourceFiles,
+      runtime: workerManifest.runtime,
+      runtimeVersion: workerManifest.runtimeVersion,
       buildPlatform,
       targetPlatform,
     };
 
-    const createResponse = await cliApiClient.createDeploymentBackgroundWorker(
-      deploymentId,
-      backgroundWorkerBody
-    );
+    console.log("Writing index-metadata.json");
 
-    if (!createResponse.success) {
-      console.error(
-        JSON.stringify({
-          message: "Failed to create background worker",
-          buildPlatform,
-          targetPlatform,
-          error: createResponse.error,
-        })
-      );
-      // Do NOT fail the deployment, this may be a multi-platform deployment
-      return;
-    }
+    await writeFile(join(process.cwd(), "index-metadata.json"), JSON.stringify(indexMetadata, null, 2));
 
     console.log(
       JSON.stringify({
-        message: "Background worker created",
+        message: "Indexing completed",
         buildPlatform,
         targetPlatform,
-        createResponse: createResponse.data,
+        taskCount: workerManifest.tasks.length,
       })
     );
   } catch (error) {
@@ -146,7 +122,11 @@ async function indexDeployment({
 
     console.error("Failed to index deployment", serialiedIndexError);
 
-    await cliApiClient.failDeployment(deploymentId, { error: serialiedIndexError });
+    // Write error to a file so it can be retrieved after the build
+    await writeFile(
+      join(process.cwd(), "index-error.json"), 
+      JSON.stringify({ error: serialiedIndexError }, null, 2)
+    );
 
     process.exit(1);
   }


### PR DESCRIPTION
# Adds support for two-phase deployments and enhanced security configurations

Adds support for splitting deployment into separate build and register phases. New CLI options: --build-only, --register-only, --registry, --repository, --base-image-node, --containerfile-module, --skip-digest.

Also adds: worker pod service account configuration, security context, DEPLOY_VERSION_SUFFIX env var, custom containerfile module support, and index metadata extraction from Docker images.

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

_[Describe the steps you took to test this change]_

---

## Changelog

### Added
- Two-phase deployment support with `--build-only` and `--register-only` CLI flags
- Custom base image support via `--base-image-node` flag
- Custom containerfile template support via `--containerfile-module` flag
- Worker pod service account configuration in Kubernetes
- Security contexts for worker pods (runAsNonRoot, capabilities drop)
- DEPLOY_VERSION_SUFFIX environment variable for version suffixes
- Index metadata extraction from Docker builds for local deployments
- Version comparison support for deployment versions with suffixes
- Example containerfile templates for custom base images and distroless builds

### Changed
- Kubernetes worker pods now run with enhanced security contexts
- Deployment version calculation now supports optional suffixes
- Docker build process extracts index files for local builds
- Temporary CVE fix: removed --frozen-lockfile for supervisor builds

### Fixed
- Version sorting in deployment lists now handles suffixes correctly
- Background worker selection uses proper version comparison

---

## Screenshots

_[Screenshots]_

💯