### PR TITLE
feat(webapp) (ENG-9310): add DEPLOY_IMAGE_OVERRIDE env var for custom image refe…

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -335,6 +335,10 @@ const EnvironmentSchema = z
 
     DEPLOY_IMAGE_PLATFORM: z.string().default("linux/amd64"),
     DEPLOY_VERSION_SUFFIX: z.string().optional(),
+    // Full image reference override - bypasses auto-generation of image tags
+    // When set, all deployments will use this exact image reference
+    // Example: "myregistry.com/myorg/myapp:1.0.5"
+    DEPLOY_IMAGE_OVERRIDE: z.string().optional(),
     DEPLOY_TIMEOUT_MS: z.coerce
       .number()
       .int()

--- a/apps/webapp/app/v3/services/initializeDeployment.server.ts
+++ b/apps/webapp/app/v3/services/initializeDeployment.server.ts
@@ -124,29 +124,46 @@ export class InitializeDeploymentService extends BaseService {
 
       const deploymentShortCode = nanoid(8);
 
-      const [imageRefError, imageRefResult] = await tryCatch(
-        getDeploymentImageRef({
-          registry: registryConfig,
-          projectRef: environment.project.externalRef,
-          nextVersion,
-          environmentType: environment.type,
-          deploymentShortCode,
-        })
-      );
+      // If DEPLOY_IMAGE_OVERRIDE is set, use it instead of generating an image reference
+      let imageRef: string;
+      let isEcr = false;
+      let repoCreated = false;
 
-      if (imageRefError) {
-        logger.error("Failed to get deployment image ref", {
+      if (env.DEPLOY_IMAGE_OVERRIDE) {
+        imageRef = env.DEPLOY_IMAGE_OVERRIDE;
+        logger.info("Using image override", {
+          imageRef,
           environmentId: environment.id,
           projectId: environment.projectId,
           version: nextVersion,
-          triggeredById: triggeredBy?.id,
-          type: payload.type,
-          cause: imageRefError.message,
         });
-        throw new ServiceValidationError("Failed to get deployment image ref");
-      }
+      } else {
+        const [imageRefError, imageRefResult] = await tryCatch(
+          getDeploymentImageRef({
+            registry: registryConfig,
+            projectRef: environment.project.externalRef,
+            nextVersion,
+            environmentType: environment.type,
+            deploymentShortCode,
+          })
+        );
 
-      const { imageRef, isEcr, repoCreated } = imageRefResult;
+        if (imageRefError) {
+          logger.error("Failed to get deployment image ref", {
+            environmentId: environment.id,
+            projectId: environment.projectId,
+            version: nextVersion,
+            triggeredById: triggeredBy?.id,
+            type: payload.type,
+            cause: imageRefError.message,
+          });
+          throw new ServiceValidationError("Failed to get deployment image ref");
+        }
+
+        imageRef = imageRefResult.imageRef;
+        isEcr = imageRefResult.isEcr;
+        repoCreated = imageRefResult.repoCreated;
+      }
 
       // We keep using `BUILDING` as the initial status if not explicitly set
       // to avoid changing the behavior for deployments not created in the build server.


### PR DESCRIPTION
## Add DEPLOY_IMAGE_OVERRIDE environment variable for custom container image references

When set, bypasses auto-generation of image tags and uses the provided image reference directly for all deployments.

Closes #<issue>

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

---

## Changelog

Added `DEPLOY_IMAGE_OVERRIDE` environment variable that allows specifying a custom container image reference. When configured, the deployment service will use this exact image reference instead of generating one automatically through the registry configuration. The variable accepts full image references in the format "registry.com/org/app:tag".

---

## Screenshots

💯