### PR TITLE
fix(chart): respect clickhouse.auth.existingSecret + expose webapp/electric extras

### DIFF
--- a/hosting/k8s/helm/templates/_helpers.tpl
+++ b/hosting/k8s/helm/templates/_helpers.tpl
@@ -401,11 +401,14 @@ ClickHouse hostname
 {{/*
 ClickHouse URL for application (with secure parameter)
 
-Note on the external+existingSecret branch: the password is expanded via
+Note on `$(CLICKHOUSE_PASSWORD)`: the password is expanded via
 Kubernetes' `$(VAR)` syntax, not shell `${VAR}`. Kubelet substitutes
 `$(CLICKHOUSE_PASSWORD)` at container-creation time from the
 CLICKHOUSE_PASSWORD env var declared just before CLICKHOUSE_URL in
-webapp.yaml. Shell-style `${...}` does not work here because
+webapp.yaml. Both the `deploy: true` and external+existingSecret
+branches use this placeholder so that the chart never bakes the
+password literal into a rendered URL string. Shell-style `${...}`
+does not work here because
 `docker/scripts/entrypoint.sh` assigns CLICKHOUSE_URL to GOOSE_DBSTRING
 with a single-pass expansion (`export GOOSE_DBSTRING="$CLICKHOUSE_URL"`),
 so any inner `${...}` reaches goose verbatim and fails URL parsing.
@@ -418,7 +421,7 @@ hex-encoded password or percent-encode before storing in the Secret.
 {{- if .Values.clickhouse.deploy -}}
 {{- $protocol := ternary "https" "http" .Values.clickhouse.secure -}}
 {{- $secure := ternary "true" "false" .Values.clickhouse.secure -}}
-{{ $protocol }}://{{ .Values.clickhouse.auth.username }}:{{ .Values.clickhouse.auth.password }}@{{ include "trigger-v4.clickhouse.hostname" . }}:8123?secure={{ $secure }}
+{{ $protocol }}://{{ .Values.clickhouse.auth.username }}:$(CLICKHOUSE_PASSWORD)@{{ include "trigger-v4.clickhouse.hostname" . }}:8123?secure={{ $secure }}
 {{- else if .Values.clickhouse.external.host -}}
 {{- $protocol := ternary "https" "http" .Values.clickhouse.external.secure -}}
 {{- $secure := ternary "true" "false" .Values.clickhouse.external.secure -}}
@@ -439,7 +442,7 @@ applies to the replication URL.
 {{- define "trigger-v4.clickhouse.replication.url" -}}
 {{- if .Values.clickhouse.deploy -}}
 {{- $protocol := ternary "https" "http" .Values.clickhouse.secure -}}
-{{ $protocol }}://{{ .Values.clickhouse.auth.username }}:{{ .Values.clickhouse.auth.password }}@{{ include "trigger-v4.clickhouse.hostname" . }}:8123
+{{ $protocol }}://{{ .Values.clickhouse.auth.username }}:$(CLICKHOUSE_PASSWORD)@{{ include "trigger-v4.clickhouse.hostname" . }}:8123
 {{- else if .Values.clickhouse.external.host -}}
 {{- $protocol := ternary "https" "http" .Values.clickhouse.external.secure -}}
 {{- if .Values.clickhouse.external.existingSecret -}}

--- a/hosting/k8s/helm/templates/electric.yaml
+++ b/hosting/k8s/helm/templates/electric.yaml
@@ -91,11 +91,19 @@ spec:
             {{- toYaml .Values.electric.resources | nindent 12 }}
           {{- with .Values.electric.extraVolumeMounts }}
           volumeMounts:
+            {{- if kindIs "string" . }}
+            {{- tpl . $ | nindent 12 }}
+            {{- else }}
             {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
           {{- end }}
       {{- with .Values.electric.extraVolumes }}
       volumes:
+        {{- if kindIs "string" . }}
+        {{- tpl . $ | nindent 8 }}
+        {{- else }}
         {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
       {{- end }}
 ---
 apiVersion: v1

--- a/hosting/k8s/helm/templates/electric.yaml
+++ b/hosting/k8s/helm/templates/electric.yaml
@@ -89,6 +89,14 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.electric.resources | nindent 12 }}
+          {{- with .Values.electric.extraVolumeMounts }}
+          volumeMounts:
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+      {{- with .Values.electric.extraVolumes }}
+      volumes:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -374,7 +374,17 @@ spec:
             - name: INTERNAL_OTEL_METRIC_EXPORTER_INTERVAL_MS
               value: {{ .Values.webapp.observability.metrics.exporterIntervalMs | quote }}
             {{- end }}
-            {{- if and .Values.clickhouse.external.host .Values.clickhouse.external.existingSecret }}
+            {{- if .Values.clickhouse.deploy }}
+            - name: CLICKHOUSE_PASSWORD
+              {{- if .Values.clickhouse.auth.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.auth.existingSecret }}
+                  key: {{ .Values.clickhouse.auth.existingSecretKey | default "admin-password" }}
+              {{- else }}
+              value: {{ .Values.clickhouse.auth.password | quote }}
+              {{- end }}
+            {{- else if and .Values.clickhouse.external.host .Values.clickhouse.external.existingSecret }}
             - name: CLICKHOUSE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -88,7 +88,11 @@ spec:
             - name: shared
               mountPath: /home/node/shared
         {{- with .Values.webapp.extraInitContainers }}
+        {{- if kindIs "string" . }}
+        {{- tpl . $ | nindent 8 }}
+        {{- else }}
         {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
         {{- end }}
       containers:
         - name: token-syncer
@@ -428,7 +432,11 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- with .Values.webapp.extraContainers }}
+        {{- if kindIs "string" . }}
+        {{- tpl . $ | nindent 8 }}
+        {{- else }}
         {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
         {{- end }}
       volumes:
         - name: shared

--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -88,7 +88,7 @@ spec:
             - name: shared
               mountPath: /home/node/shared
         {{- with .Values.webapp.extraInitContainers }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       containers:
         - name: token-syncer
@@ -428,7 +428,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- with .Values.webapp.extraContainers }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       volumes:
         - name: shared

--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -77,18 +77,31 @@ spec:
           image: {{ include "trigger-v4.webapp.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.webapp.volumePermissions.image.pullPolicy }}
           command: ['sh', '-c', 'mkdir -p /home/node/shared']
+          {{- with .Values.webapp.initContainers.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
           securityContext:
             runAsUser: 1000
+          {{- end }}
           volumeMounts:
             - name: shared
               mountPath: /home/node/shared
+        {{- with .Values.webapp.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: token-syncer
           image: {{ include "trigger-v4.webapp.tokenSyncer.image" . }}
           imagePullPolicy: {{ .Values.webapp.tokenSyncer.image.pullPolicy }}
+          {{- with .Values.webapp.sidecarContainers.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
           securityContext:
             runAsUser: 1000
             runAsNonRoot: true
+          {{- end }}
           command:
             - /bin/bash
             - -c
@@ -414,6 +427,9 @@ spec:
             {{- with .Values.webapp.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- with .Values.webapp.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
         - name: shared
           {{- if .Values.persistence.shared.enabled }}

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -172,6 +172,44 @@ webapp:
     #   mountPath: /etc/ssl/certs
     #   readOnly: true
 
+  # Extra containers added to the webapp pod (sidecars). Useful for
+  # in-pod TLS (nginx, envoy), log shippers, audit agents, etc.
+  extraContainers:
+    []
+    # - name: nginx-tls
+    #   image: nginx:alpine
+    #   ports:
+    #     - name: https-internal
+    #       containerPort: 3031
+    #   volumeMounts:
+    #     - name: nginx-config
+    #       mountPath: /etc/nginx/conf.d
+    #     - name: nginx-tls-certs
+    #       mountPath: /etc/nginx/tls
+
+  # Extra init containers added to the webapp pod, scheduled after the
+  # built-in `volume-permissions` init.
+  extraInitContainers:
+    []
+    # - name: wait-for-secrets
+    #   image: busybox
+    #   command: [...]
+
+  # Container-level securityContext applied to the built-in
+  # `volume-permissions` init container. When unset, defaults to
+  # `runAsUser: 1000`. Set this to enforce stricter pod-security
+  # admission (e.g. FIPS / FedRAMP / Pod Security Standards "restricted":
+  # `runAsNonRoot: true`, `allowPrivilegeEscalation: false`,
+  # `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`).
+  initContainers:
+    securityContext: {}
+
+  # Container-level securityContext applied to the built-in `token-syncer`
+  # sidecar. Same shape + intent as `webapp.initContainers.securityContext`.
+  # Defaults to `{ runAsUser: 1000, runAsNonRoot: true }` when unset.
+  sidecarContainers:
+    securityContext: {}
+
   # ServiceMonitor for Prometheus monitoring
   serviceMonitor:
     enabled: false

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -550,7 +550,16 @@ clickhouse:
   # Bitnami ClickHouse chart configuration (when deploy: true)
   auth:
     username: "default"
-    password: "password"
+    password: "password" # Optional - ignored if existingSecret is set
+    #
+    # Secure credential management. When set, the chart resolves
+    # CLICKHOUSE_PASSWORD from this Secret (via Kubernetes' `$(VAR)` env
+    # substitution in the rendered URL) instead of baking the literal
+    # `password` above into the URL helper. The Bitnami ClickHouse
+    # subchart also reads the same fields, so the running ClickHouse
+    # pod and the webapp agree on the password.
+    existingSecret: "" # Name of existing secret containing password
+    existingSecretKey: "admin-password" # Key in existing secret containing password
 
   # Single-node configuration (disable clustering for dev/test)
   keeper:

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -572,6 +572,27 @@ electric:
     # - name: CUSTOM_VAR
     #   value: "custom-value"
 
+  # Extra volumes added to the Electric pod. Use cases include providing
+  # the `/app/persistent` mount Electric needs at runtime (e.g. as an
+  # emptyDir or PVC), or mounting an enterprise CA bundle.
+  extraVolumes:
+    []
+    # - name: persistent
+    #   emptyDir: {}
+    # - name: ca-bundle
+    #   configMap:
+    #     name: enterprise-ca-bundle
+
+  # Extra volume mounts added to the Electric container. Pair with the
+  # corresponding entries in `extraVolumes`.
+  extraVolumeMounts:
+    []
+    # - name: persistent
+    #   mountPath: /app/persistent
+    # - name: ca-bundle
+    #   mountPath: /etc/ssl/enterprise-ca
+    #   readOnly: true
+
 # ClickHouse configuration
 # Subchart: https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
 clickhouse:


### PR DESCRIPTION
## Summary

Three Helm chart improvements found while rebasing our trigger.dev fork:

1. **ClickHouse password indirection** — fixes a real bug where setting `clickhouse.auth.existingSecret` is silently ignored when `clickhouse.deploy: true`. Helper baked `auth.password` literal into the URL while the Bitnami ClickHouse pod read the real password from the secret → HTTP 401 on every CH query. Fix uses `$(CLICKHOUSE_PASSWORD)` kubelet env substitution.

2. **webapp extras** — adds `extraContainers`, `extraInitContainers`, `initContainers.securityContext`, `sidecarContainers.securityContext` matching the pattern already supported on the supervisor. Lets operators inject TLS sidecars, audit-logger sidecars, etc. without forking the chart.

3. **electric extras** — adds `extraVolumes` / `extraVolumeMounts` (same pattern as webapp/supervisor). Lets operators provide the writable `/app/persistent` mount Electric needs at runtime, plus optional extras like CA bundles.

## Notes

- Defaults preserve current behavior.
- Each change is its own commit; happy to split into 3 separate PRs if preferred.
- PR 2 of 5 from a fork rebase.

Made with [Cursor](https://cursor.com)