### PR TITLE
feat(webapp): add DEPLOY_IMAGE_OVERRIDE env var (single-tenant only)

### DIFF
--- a/.changeset/deploy-image-override.md
+++ b/.changeset/deploy-image-override.md
@@ -1,0 +1,9 @@
+---
+"trigger.dev": minor
+---
+
+webapp: add `DEPLOY_IMAGE_OVERRIDE` env var (single-tenant only)
+
+Adds a new `DEPLOY_IMAGE_OVERRIDE` env var on the webapp. When set, every deployment finalized by this webapp instance is wired to the configured image reference instead of being routed through the default per-deployment image computation (`getDeploymentImageRef`). Useful for self-hosted single-tenant installs where CI builds one canonical tasks image per release and the chart-managed registry / per-project tagging is unnecessary.
+
+⚠️ **WARNING: SINGLE-TENANT ONLY.** This is a foot-gun on cloud / multi-tenant installs where deployments come from untrusted user code: a single operator-set value silently overrides every tenant's per-project image. The env var ships unset by default; the docstring in `apps/webapp/app/env.server.ts` and this changeset call out the risk. Leave unset on multi-tenant installs.

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -433,6 +433,38 @@ const EnvironmentSchema = z
       ),
 
     DEPLOY_IMAGE_PLATFORM: z.string().default("linux/amd64"),
+    /**
+     * DEPLOY_IMAGE_OVERRIDE — full image reference override; bypasses
+     * auto-generation of image tags. When set, every deployment finalized
+     * by this webapp instance uses this exact image reference instead of
+     * being routed through `getDeploymentImageRef` (ECR repo creation,
+     * per-project tagging, isEcr/repoCreated detection, etc).
+     *
+     * ⚠️  WARNING: SINGLE-TENANT ONLY. ⚠️
+     *
+     * When set, every deployment finalized by this webapp instance will be
+     * wired to this image, regardless of which org / project triggered it.
+     * This is a foot-gun for any multi-tenant trigger.dev install
+     * (including Cloud) where deployments come from untrusted user code:
+     * one operator-set value silently overrides every tenant's per-project
+     * image. Only enable when BOTH of the following hold:
+     *   - You control the build pipeline producing the image (e.g. your CI
+     *     builds + pushes a single canonical tasks image per release), AND
+     *   - The install serves only your own org's projects (self-hosted,
+     *     single-tenant).
+     *
+     * For cloud / multi-tenant: leave unset. The deployment image is
+     * normally computed per-deployment from the registry config and the
+     * deploy version, which keeps tenants isolated.
+     *
+     * Empty string is treated as unset.
+     *
+     * Example: `myregistry.com/myorg/myapp:1.0.5`
+     */
+    DEPLOY_IMAGE_OVERRIDE: z
+      .string()
+      .optional()
+      .transform((v) => (v && v.length > 0 ? v : undefined)),
     DEPLOY_TIMEOUT_MS: z.coerce
       .number()
       .int()

--- a/apps/webapp/app/v3/services/initializeDeployment.server.ts
+++ b/apps/webapp/app/v3/services/initializeDeployment.server.ts
@@ -198,13 +198,23 @@ export class InitializeDeploymentService extends BaseService {
         environment.id,
         async (nextVersion) => {
           const [imageRefError, imageRefResult] = await tryCatch(
-            getDeploymentImageRef({
-              registry: registryConfig,
-              projectRef: environment.project.externalRef,
-              nextVersion,
-              environmentType: environment.type,
-              deploymentShortCode,
-            })
+            (async () => {
+              if (env.DEPLOY_IMAGE_OVERRIDE) {
+                return {
+                  imageRef: env.DEPLOY_IMAGE_OVERRIDE,
+                  isEcr: false,
+                  repoCreated: false,
+                };
+              }
+
+              return getDeploymentImageRef({
+                registry: registryConfig,
+                projectRef: environment.project.externalRef,
+                nextVersion,
+                environmentType: environment.type,
+                deploymentShortCode,
+              });
+            })()
           );
 
           if (imageRefError) {


### PR DESCRIPTION
## Summary

Adds a `DEPLOY_IMAGE_OVERRIDE` env var that lets self-hosted operators force every finalized deployment to use a specific image, instead of the default per-deployment image computation (`getDeploymentImageRef` — registry config, project ref, deploy shortcode, ECR repo creation, etc.).

⚠️ **WARNING: SINGLE-TENANT ONLY.** This env var is a foot-gun for any multi-tenant trigger.dev install (including Cloud). When set, every tenant's deployments get the same image. Only useful when:
  - You control the build pipeline producing the image (e.g. your CI builds + pushes one canonical tasks image per release)
  - AND the install serves only your own org's projects (self-hosted single-tenant)

The env.server.ts docstring + the changeset both call out the risk explicitly. Default behavior is unchanged (env unset).

## Changes

- `apps/webapp/app/env.server.ts`: Zod schema for the new env var, with the warning docstring
- `apps/webapp/app/v3/services/initializeDeployment.server.ts`: short-circuits the image-ref path inside the existing per-attempt callback when the env is set
- `.changeset/deploy-image-override.md`: minor bump + multi-tenant warning

## Test plan

- Unit test: env var unset → behavior unchanged (existing path through `getDeploymentImageRef`)
- Unit test: env var set → finalized deployment uses the override image, `isEcr: false`, `repoCreated: false`
- Manually verified in a self-hosted single-tenant environment: every deployment gets the configured image reference

## Notes

- Single-tenant only. Hard "do not enable on cloud / multi-tenant" warning in `env.server.ts` docstring + changeset.
- PR 3 of 5 from a fork rebase.

Made with [Cursor](https://cursor.com)