### PR TITLE
feat(chart/webapp): add s3.external.useIam to support IRSA / Workload Identity

### DIFF
--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -314,7 +314,7 @@ spec:
                   name: {{ include "trigger-v4.secretsName" . }}
                   key: s3-auth-secret-access-key
             {{- end }}
-            {{- else }}
+            {{- else if not .Values.s3.external.useIam }}
             {{- if .Values.s3.external.existingSecret }}
             - name: OBJECT_STORE_ACCESS_KEY_ID
               valueFrom:

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -650,6 +650,14 @@ s3:
     accessKeyId: "admin" # Default for internal MinIO - change for production
     secretAccessKey: "very-safe-password" # Default for internal MinIO - change for production
     #
+    # IAM-based authentication (for AWS S3 with IRSA / GCP Workload Identity).
+    # When true, the webapp pod skips the OBJECT_STORE_ACCESS_KEY_ID /
+    # OBJECT_STORE_SECRET_ACCESS_KEY env vars entirely so the AWS SDK can
+    # fall back to its credential-provider chain (instance metadata,
+    # web-identity-token file, etc.). Pair with a ServiceAccount
+    # `eks.amazonaws.com/role-arn` annotation on `webapp.serviceAccount`.
+    useIam: false
+    #
     # Secure credential management
     existingSecret: "" # Name of existing secret containing S3 credentials
     existingSecretAccessKeyIdKey: "access-key-id" # Key in existing secret containing access key ID


### PR DESCRIPTION
## Summary

Adds `s3.external.useIam` to the Helm chart. When true, the webapp skips mounting `OBJECT_STORE_ACCESS_KEY_ID` / `OBJECT_STORE_SECRET_ACCESS_KEY` env vars so the AWS SDK can use IRSA (EKS) / Workload Identity (GKE) / instance metadata for credentials.

Pure additive change — `useIam: false` default preserves current behavior.

## Notes

- PR 4 of 5 from a fork rebase.
- Pair with a `eks.amazonaws.com/role-arn` annotation on `webapp.serviceAccount` for IRSA.

Made with [Cursor](https://cursor.com)