### PR TITLE
feat(docker): add 'migrate' subcommand to entrypoint.sh

### DIFF
--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -xe
 
+if [ "$1" = "migrate" ]; then
+  echo "Running migrations only (entrypoint.sh migrate mode)"
+  SKIP_POSTGRES_MIGRATIONS=0
+fi
+
 if [ -n "$DATABASE_HOST" ]; then
   scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
 fi
@@ -37,6 +42,11 @@ elif [ "$SKIP_CLICKHOUSE_MIGRATIONS" = "1" ]; then
   echo "SKIP_CLICKHOUSE_MIGRATIONS=1, skipping ClickHouse migrations."
 else
   echo "CLICKHOUSE_URL not set, skipping ClickHouse migrations."
+fi
+
+if [ "$1" = "migrate" ]; then
+  echo "Migrations complete, exiting."
+  exit 0
 fi
 
 # Copy over required prisma files


### PR DESCRIPTION
## Summary

Adds a `migrate` positional subcommand to `docker/scripts/entrypoint.sh` so the same app image can be used as a pre-install Helm migration Job container without booting the webapp server.

10-line shell change. Backwards-compatible — no behavior change without the subcommand.

## Test plan

- Run `entrypoint.sh` with no args → existing behavior (migrations + exec webapp)
- Run `entrypoint.sh migrate` → forces SKIP_POSTGRES_MIGRATIONS=0, runs prisma + goose, exits 0

## Notes

- PR 5 of 5 from a fork rebase.

Made with [Cursor](https://cursor.com)