### PR TITLE
feat(cli-v3): expose ./internal subpath for programmatic build/deploy

### DIFF
--- a/packages/cli-v3/package.json
+++ b/packages/cli-v3/package.json
@@ -45,7 +45,8 @@
     ],
     "exports": {
       "./package.json": "./package.json",
-      ".": "./src/index.ts"
+      ".": "./src/index.ts",
+      "./internal": "./src/internal.ts"
     }
   },
   "devDependencies": {
@@ -158,6 +159,12 @@
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
+      }
+    },
+    "./internal": {
+      "import": {
+        "types": "./dist/esm/internal.d.ts",
+        "default": "./dist/esm/internal.js"
       }
     }
   }

--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -708,7 +708,7 @@ export async function generateContainerfile(options: GenerateContainerfileOption
   }
 }
 
-const parseGenerateOptions = (options: GenerateContainerfileOptions) => {
+export const parseGenerateOptions = (options: GenerateContainerfileOptions) => {
   const buildArgs = Object.entries(options.build.env || {})
     .flatMap(([key]) => `ARG ${key}`)
     .join("\n");

--- a/packages/cli-v3/src/internal.ts
+++ b/packages/cli-v3/src/internal.ts
@@ -1,0 +1,33 @@
+// Public API surface for downstream tooling that wants to drive the
+// build / deploy pipeline programmatically without going through the
+// `trigger` CLI binary.
+//
+// Mirrors the pattern used by `@trigger.dev/build`'s `./internal` subpath:
+// the modules exported here are stable enough to be consumed by adjacent
+// packages, but they sit *below* the documented CLI command surface, so
+// consumers should pin to a specific version of this package.
+
+// Build / deploy primitives
+export { loadConfig } from "./config.js";
+export { buildWorker } from "./build/buildWorker.js";
+export { buildImage, parseGenerateOptions } from "./deploy/buildImage.js";
+
+// Auth + project-environment resolution. `login` reads TRIGGER_ACCESS_TOKEN
+// from the env when present (so it works in CI without a config file);
+// `getProjectClient` performs the two-step engine API URL discovery and
+// returns an engine-bound CliApiClient that callers use for all subsequent
+// deploy/register/finalize/fail API calls.
+export { login } from "./commands/login.js";
+export { getProjectClient } from "./utilities/session.js";
+
+// Deploy-time env var sync (deploy.sync.env / .parentEnv -> POST .../envvars/import).
+export { syncEnvVarsWithServer } from "./commands/deploy.js";
+
+// Build-host helpers used by the deploy flow:
+//   - resolveLocalEnvVars / loadDotEnvVars: read project-local .env files
+//   - createGitMeta: extract git metadata for the deployment record
+//   - getTmpDir: scoped temp directory with cleanup tracking
+export { resolveLocalEnvVars } from "./utilities/localEnvVars.js";
+export { loadDotEnvVars } from "./utilities/dotEnv.js";
+export { createGitMeta } from "./utilities/gitMeta.js";
+export { getTmpDir } from "./utilities/tempDirectories.js";


### PR DESCRIPTION
## Summary

Adds the `./internal` subpath export to `packages/cli-v3` (mirrors `@trigger.dev/build`'s existing `./internal` pattern) so external tooling can drive build and deploy programmatically without shelling out to the `trigger` binary.

11 named exports across build/deploy primitives, auth + project resolution, deploy-time env sync, and build-host helpers. Each one wraps a helper that the cli-v3 commands already use internally — this PR just makes them importable from a stable subpath.

## Why

We discovered this while building a custom multi-stage tasks-image build pipeline for an air-gapped environment. The pipeline needs to call `loadConfig` → `buildWorker` → `buildImage` directly, then later (in a separate pod) call `login` → `getProjectClient` → various deployment-API methods. Doing that via the `trigger` CLI binary requires shelling out, parsing exit codes, etc. Importing from `trigger.dev/internal` is much cleaner.

## Stability

Each export wraps an existing internal helper. The subpath is documented as "consumers should pin to a specific cli-v3 version — the surface sits below the CLI command boundary, signatures may change." Adopters opt into the semver liability explicitly.

## Test plan

- `pnpm typecheck` passes
- Existing cli-v3 tests pass
- `pnpm pack` produces a tarball with `dist/esm/internal.js` present
- Confirmed `import { loadConfig } from 'trigger.dev/internal'` resolves correctly in a downstream consumer

## Notes

- PR 6 of 8 from a fork rebase. PRs 1-5 (#14, #15, #16, #17, #18) opened earlier.
- 11 exports because `setGithubActionsOutputAndEnvVars` was removed (only useful when running under GitHub Actions, no-op otherwise).

Made with [Cursor](https://cursor.com)