### PR TITLE
feat(chart/supervisor): expose extraVolumes / extraVolumeMounts

### DIFF
--- a/hosting/k8s/helm/templates/supervisor.yaml
+++ b/hosting/k8s/helm/templates/supervisor.yaml
@@ -248,7 +248,7 @@ spec:
               mountPath: /home/node/shared
             {{- end }}
             {{- with .Values.supervisor.extraVolumeMounts }}
-            {{- toYaml . | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
           {{- end }}
           {{- with .Values.supervisor.securityContext }}
@@ -267,7 +267,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- with .Values.supervisor.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- with .Values.supervisor.nodeSelector }}

--- a/hosting/k8s/helm/templates/supervisor.yaml
+++ b/hosting/k8s/helm/templates/supervisor.yaml
@@ -248,7 +248,11 @@ spec:
               mountPath: /home/node/shared
             {{- end }}
             {{- with .Values.supervisor.extraVolumeMounts }}
+            {{- if kindIs "string" . }}
+            {{- tpl . $ | nindent 12 }}
+            {{- else }}
             {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
             {{- end }}
           {{- end }}
           {{- with .Values.supervisor.securityContext }}
@@ -267,7 +271,11 @@ spec:
           {{- end }}
         {{- end }}
         {{- with .Values.supervisor.extraVolumes }}
+        {{- if kindIs "string" . }}
+        {{- tpl . $ | nindent 8 }}
+        {{- else }}
         {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
         {{- end }}
       {{- end }}
       {{- with .Values.supervisor.nodeSelector }}

--- a/hosting/k8s/helm/templates/supervisor.yaml
+++ b/hosting/k8s/helm/templates/supervisor.yaml
@@ -241,17 +241,23 @@ spec:
             {{- with .Values.supervisor.extraEnvVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if not .Values.webapp.bootstrap.enabled }}
+          {{- if or (not .Values.webapp.bootstrap.enabled) .Values.supervisor.extraVolumeMounts }}
           volumeMounts:
+            {{- if not .Values.webapp.bootstrap.enabled }}
             - name: shared
               mountPath: /home/node/shared
+            {{- end }}
+            {{- with .Values.supervisor.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.supervisor.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if not .Values.webapp.bootstrap.enabled }}
+      {{- if or (not .Values.webapp.bootstrap.enabled) .Values.supervisor.extraVolumes }}
       volumes:
+        {{- if not .Values.webapp.bootstrap.enabled }}
         - name: shared
           {{- if .Values.persistence.shared.enabled }}
           persistentVolumeClaim:
@@ -259,6 +265,10 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
+        {{- with .Values.supervisor.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.supervisor.nodeSelector }}
       nodeSelector:

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -336,6 +336,44 @@ supervisor:
     # - name: CUSTOM_VAR
     #   value: "custom-value"
 
+  # Extra volumes added to the Supervisor pod.
+  #
+  # Mirrors the `webapp.extraVolumes` pattern. The most common use case is
+  # mounting an enterprise CA bundle into the supervisor so it can validate
+  # TLS connections to the trigger.dev webapp, an internal image registry,
+  # or any other service the supervisor calls. Pair with a matching
+  # `extraVolumeMounts` entry below and a `NODE_EXTRA_CA_CERTS` env var in
+  # `supervisor.extraEnvVars`.
+  extraVolumes:
+    []
+    # - name: config-volume
+    #   configMap:
+    #     name: my-config
+    #
+    # Example: enterprise CA bundle ConfigMap
+    # - name: ca-bundle
+    #   configMap:
+    #     name: enterprise-ca-bundle
+    #     items:
+    #       - key: ca.crt
+    #         path: ca.crt
+
+  # Extra volume mounts added to the Supervisor container.
+  extraVolumeMounts:
+    []
+    # - name: config-volume
+    #   mountPath: /etc/config
+    #   readOnly: true
+    #
+    # Example: enterprise CA bundle mount.
+    # Combine with:
+    #   supervisor.extraEnvVars:
+    #     - name: NODE_EXTRA_CA_CERTS
+    #       value: /etc/ssl/enterprise-ca/ca.crt
+    # - name: ca-bundle
+    #   mountPath: /etc/ssl/enterprise-ca
+    #   readOnly: true
+
   # ServiceMonitor for Prometheus monitoring
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
## Summary

Adds `supervisor.extraVolumes` / `supervisor.extraVolumeMounts` Helm values, matching the existing pattern on webapp and electric. Lets operators mount enterprise CA bundles, custom config files, etc. into the supervisor container without forking the chart.

~10 lines of YAML. Pure additive.

## Notes

- PR 8 of 8 from a fork rebase. Final follow-up; closes out Eric's review.

Made with [Cursor](https://cursor.com)