### PR TITLE
feat(chart): add webapp.service.extraPorts hook (PLT-940)

### DIFF
--- a/hosting/k8s/helm/Chart.yaml
+++ b/hosting/k8s/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trigger
 description: The official Trigger.dev Helm chart
 type: application
-version: 4.5.0-rc.4-plt663.7
+version: 4.5.0-rc.4-plt663.8
 appVersion: v4.5.0-rc.4
 home: https://trigger.dev
 sources:

--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -501,6 +501,9 @@ spec:
       targetPort: {{ .Values.webapp.service.servicePortTargetPort | default .Values.webapp.service.targetPort | default "http" }}
       protocol: TCP
       name: {{ .Values.webapp.service.name | default "http" }}
+    {{- with .Values.webapp.service.extraPorts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   selector:
     {{- include "trigger-v4.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" $component) | nindent 4 }}
 ---

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -75,6 +75,11 @@ webapp:
     type: ClusterIP
     port: 3030
     targetPort: 3000
+    # Extra Service ports merged into the webapp Service. Use to expose an
+    # in-cluster-only port (e.g. the embedded s2-lite :8080 for realtime
+    # streams) on the existing Service without a separate Service or TLS.
+    # Each entry must be named (k8s requires names once a Service has >1 port).
+    extraPorts: []
 
   podAnnotations: {}
 


### PR DESCRIPTION
## Summary

Adds a `webapp.service.extraPorts` hook to the webapp Service template so additional in-cluster ports can be merged onto the existing `<release>-webapp` Service via values — without a separate Service or TLS.

**Why:** In TLS-off environments (e.g. GameWarden, where there are no Palantir Rubix pod-certs), the umbrella's `webapp-internal` Service — gated on `nginx.tls.enabled` — doesn't render. That Service is the only thing exposing the webapp pod's embedded **s2-lite `:8080`** port to other in-cluster pods, so `REALTIME_STREAMS_S2_ENDPOINT` has no routable target and client-side realtime streams break. This hook lets the umbrella add the s2 port to the existing `trigger-webapp` Service (the AO-compliant "port on an existing Service" pattern), with no new object and no TLS.

FedStart is unaffected: it runs TLS-on, so `webapp-internal` still carries the s2 port; `extraPorts` defaults to `[]` so existing renders are byte-identical.

## Changes
- `templates/webapp.yaml`: append `{{- with .Values.webapp.service.extraPorts }}` to the webapp Service `ports`.
- `values.yaml`: document + default `webapp.service.extraPorts: []`.
- `Chart.yaml`: bump `4.5.0-rc.4-plt663.7` → `4.5.0-rc.4-plt663.8`.

## Test plan
- [x] `helm dependency build` + `helm lint` pass.
- [x] `helm template` with extraPorts renders the webapp Service with both `3030→3000 (http)` and `8080→8080 (s2-lite)`.
- [x] Empty default produces no diff vs. before.
- [ ] Prerelease subchart published by CI; consumed by the umbrella repin (govsignals PLT-940 PR).

PLT-940

Made with [Cursor](https://cursor.com)